### PR TITLE
Refactor dashboard layout with modular assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Inky Photoframe Dashboard
+
+Een lichtgewicht dashboard voor het beheren van de Inky Photoframe fotocarrousel op een Raspberry Pi. De webinterface is geoptimaliseerd voor e-ink schermen (hoog contrast, beperkte kleuren) en draait zonder externe frameworks zodat alles responsief blijft op een Pi Zero.
+
+## Starten
+
+```bash
+./photo.py
+```
+
+De server start standaard op poort `8080` en serveert de interface via `http://<pi-adres>:8080/`. Afbeeldingen worden opgeslagen onder `/image` (pas dit aan in `photo.py` als je een andere map wilt gebruiken). De eerste start maakt de map automatisch aan.
+
+## Front-end structuur
+
+- `templates/index.html` – dashboardlayout met secties voor status, carrousel, upload, galerij, kalender en notities.
+- `static/css/main.css` – e-inkvriendelijke stijlen (lichte achtergrond, donkere typografie, beperkte accentkleur).
+- `static/js/app.js` – instappunt dat de componenten initialiseert.
+- `static/js/components/*` – kleine vanilla modules voor statuskaart, carrouselbediening, uploads, galerij en kalender.
+
+Alle assets samen blijven ruim onder de 100 KB zodat laden snel blijft, zelfs via het beperkte wifi van een Pi.
+
+## Cache & statische bestanden
+
+De server levert bestanden uit `static/` met `Cache-Control: public, max-age=3600`. Browsers kunnen de assets (CSS/JS) dus een uur cachen; een harde refresh of herstart van de server forceert nieuwe bestanden. API-antwoorden en de HTML worden met `Cache-Control: no-store` verstuurd om steeds actuele statusinformatie op te halen.
+
+## Statuspolling
+
+De statuskaart vraagt elke 10 seconden `GET /api/status` op. De kaart toont badges met de display-/carrouselstatus, een voortgangsbalk voor de resterende tijd tot de volgende wissel en werkt de notities bij. Druk op "Ververs" om direct een nieuwe status op te halen.

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,0 +1,378 @@
+:root {
+  color-scheme: light dark;
+  --ink: #111111;
+  --ink-muted: #3a3a3a;
+  --ink-invert: #f5f5f2;
+  --paper: #f2f1ec;
+  --paper-dark: #deddd7;
+  --accent: #c7372f;
+  --accent-soft: #f1c7c3;
+  --shadow: rgba(0, 0, 0, 0.05);
+  --radius: 12px;
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", "Roboto", "Helvetica", sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+  display: flex;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 1.5rem;
+}
+
+.dashboard {
+  width: min(1180px, 100%);
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  gap: 1.5rem;
+}
+
+.dashboard__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem;
+  background: var(--ink-invert);
+  border-radius: var(--radius);
+  border: 1px solid var(--paper-dark);
+  box-shadow: 0 6px 18px var(--shadow);
+}
+
+.dashboard__subtitle {
+  margin: 0.25rem 0 0;
+  color: var(--ink-muted);
+  font-size: 0.95rem;
+}
+
+.dashboard__clock {
+  font-variant-numeric: tabular-nums;
+  font-size: 2.25rem;
+  font-weight: 600;
+  color: var(--ink);
+  background: var(--paper-dark);
+  border-radius: calc(var(--radius) / 1.5);
+  padding: 0.75rem 1.25rem;
+}
+
+.dashboard__main {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-content: start;
+}
+
+.panel {
+  background: var(--ink-invert);
+  border-radius: var(--radius);
+  border: 1px solid var(--paper-dark);
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: 0 8px 20px var(--shadow);
+}
+
+.panel--wide {
+  grid-column: 1 / -1;
+}
+
+.panel--gallery {
+  grid-column: 1 / -1;
+}
+
+.panel__head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.panel__head h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.panel__tools {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.panel__messages {
+  min-height: 1.25rem;
+  font-size: 0.95rem;
+  color: var(--ink-muted);
+}
+
+.status-card {
+  display: grid;
+  gap: 1rem;
+}
+
+.status-card__error {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.status-card__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  font-size: 0.85rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid currentColor;
+  letter-spacing: 0.02em;
+}
+
+.badge--ok {
+  color: var(--ink);
+  background: #d7f0d1;
+}
+
+.badge--warn {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.badge--idle {
+  color: var(--ink-muted);
+  background: #e7e6e0;
+}
+
+.status-card__metrics {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-card__metrics dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.status-card__metrics dt {
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ink-muted);
+}
+
+.status-card__metrics dd {
+  margin: 0;
+  font-weight: 600;
+}
+
+.progress {
+  background: var(--paper-dark);
+  border-radius: 999px;
+  overflow: hidden;
+  height: 0.65rem;
+  position: relative;
+}
+
+.progress__bar {
+  background: var(--accent);
+  height: 100%;
+  display: block;
+  transition: width 0.3s ease;
+}
+
+.status-card__note,
+.status-card__timestamp {
+  margin: 0;
+  color: var(--ink-muted);
+  font-size: 0.9rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-grid__field {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+}
+
+input[type="number"],
+input[type="file"] {
+  font: inherit;
+  padding: 0.6rem 0.75rem;
+  border-radius: calc(var(--radius) / 1.5);
+  border: 1px solid var(--paper-dark);
+  background: #ffffff;
+  color: inherit;
+}
+
+input[type="file"] {
+  padding: 0.35rem 0.5rem;
+}
+
+.action-button,
+.ghost-button {
+  font: inherit;
+  padding: 0.6rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: transform 0.1s ease;
+}
+
+.action-button {
+  background: var(--accent);
+  border: 1px solid var(--accent);
+  color: var(--ink-invert);
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid var(--ink-muted);
+  color: var(--ink);
+}
+
+.action-button:active,
+.ghost-button:active {
+  transform: translateY(1px);
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.upload {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+}
+
+.upload__field {
+  flex: 1;
+  display: grid;
+  gap: 0.5rem;
+  min-width: 200px;
+}
+
+.image-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 1rem;
+}
+
+.image-card {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.75rem;
+  border: 1px solid var(--paper-dark);
+  border-radius: calc(var(--radius) / 1.5);
+  background: #ffffff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.image-card.is-current {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px rgba(199, 55, 47, 0.15);
+}
+
+.image-card__thumb {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-radius: calc(var(--radius) / 2);
+  background: var(--paper-dark);
+}
+
+.image-card__meta {
+  font-size: 0.85rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.image-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.empty-state {
+  margin: 0;
+  color: var(--ink-muted);
+  font-style: italic;
+}
+
+.calendar {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.calendar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-weight: 600;
+}
+
+.calendar__grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.calendar__grid span {
+  text-align: center;
+  padding: 0.4rem 0.2rem;
+  border-radius: calc(var(--radius) / 2);
+}
+
+.calendar__grid span.is-today {
+  background: var(--accent);
+  color: var(--ink-invert);
+}
+
+.notes-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+  color: var(--ink-muted);
+}
+
+.dashboard__footer {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+  color: var(--ink-muted);
+}
+
+@media (max-width: 720px) {
+  body {
+    padding: 1rem;
+  }
+
+  .dashboard__clock {
+    font-size: 1.6rem;
+  }
+
+  .upload {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/static/js/api.js
+++ b/static/js/api.js
@@ -1,0 +1,56 @@
+const BASE = '/api';
+
+async function handleResponse(response) {
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (error) {
+    payload = { ok: false, error: 'Ongeldig antwoord van server' };
+  }
+  if (!response.ok || (payload && payload.ok === false)) {
+    const message = payload && payload.error ? payload.error : `HTTP ${response.status}`;
+    const err = new Error(message);
+    err.response = payload;
+    err.status = response.status;
+    throw err;
+  }
+  return payload;
+}
+
+export async function getJSON(path) {
+  const response = await fetch(path.startsWith('http') ? path : `${path}`, {
+    cache: 'no-store'
+  });
+  return handleResponse(response);
+}
+
+export async function post(path, options = {}) {
+  const response = await fetch(path.startsWith('http') ? path : `${path}`, {
+    method: 'POST',
+    cache: 'no-store',
+    ...options
+  });
+  return handleResponse(response);
+}
+
+export async function postJSON(path, options = {}) {
+  return post(path, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options,
+    body: options.body || JSON.stringify(options.json || {})
+  });
+}
+
+export async function postForm(path, formData) {
+  return post(path, { body: formData });
+}
+
+export const endpoints = {
+  status: `${BASE}/status`,
+  images: `${BASE}/images`,
+  upload: `${BASE}/upload`,
+  display: `${BASE}/display`,
+  delete: `${BASE}/delete`,
+  carouselStart: `${BASE}/carousel/start`,
+  carouselStop: `${BASE}/carousel/stop`
+};

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1,0 +1,62 @@
+import { StatusCard } from './components/statusCard.js';
+import { CarouselControls } from './components/carouselControls.js';
+import { UploadManager } from './components/uploadManager.js';
+import { GalleryManager } from './components/galleryManager.js';
+import { CalendarWidget } from './components/calendarWidget.js';
+import { SystemNotes } from './components/systemNotes.js';
+
+function initClock(clockEl) {
+  if (!clockEl) return;
+  const update = () => {
+    const now = new Date();
+    clockEl.textContent = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  };
+  update();
+  setInterval(update, 60000);
+}
+
+function ready(fn) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fn);
+  } else {
+    fn();
+  }
+}
+
+ready(() => {
+  const statusCard = new StatusCard(document.querySelector('#statusCard'));
+  const carousel = new CarouselControls(
+    document.querySelector('#carouselForm'),
+    document.querySelector('#carouselMessage')
+  );
+  const gallery = new GalleryManager(
+    document.querySelector('#imageGrid'),
+    document.querySelector('#galleryEmpty'),
+    document.querySelector('#galleryMessage')
+  );
+  new UploadManager(
+    document.querySelector('#uploadForm'),
+    document.querySelector('#uploadMessage')
+  );
+  const calendar = new CalendarWidget(document.querySelector('#calendarWidget'));
+  const notes = new SystemNotes(document.querySelector('#systemNotes'));
+
+  initClock(document.querySelector('#clock'));
+  calendar.render();
+  statusCard.start();
+  gallery.load();
+
+  document.querySelector('#forceStatus')?.addEventListener('click', () => statusCard.refresh());
+  document.querySelector('#refreshGallery')?.addEventListener('click', () => gallery.load());
+
+  document.addEventListener('gallery:refresh', () => gallery.load());
+  document.addEventListener('status:update', (event) => {
+    const detail = event.detail;
+    carousel.sync(detail);
+    gallery.markCurrent(detail?.carousel?.current_file || null);
+    notes.setStatus(detail);
+  });
+  document.addEventListener('gallery:updated', (event) => {
+    notes.setGalleryCount(event.detail?.count ?? 0);
+  });
+});

--- a/static/js/components/calendarWidget.js
+++ b/static/js/components/calendarWidget.js
@@ -1,0 +1,49 @@
+const WEEKDAYS = ['Ma', 'Di', 'Wo', 'Do', 'Vr', 'Za', 'Zo'];
+
+export class CalendarWidget {
+  constructor(root) {
+    this.root = root;
+    this.today = new Date();
+  }
+
+  render() {
+    if (!this.root) return;
+    const current = new Date();
+    const monthName = current.toLocaleString('nl-NL', { month: 'long', year: 'numeric' });
+    const firstDay = new Date(current.getFullYear(), current.getMonth(), 1);
+    const startDay = (firstDay.getDay() + 6) % 7; // maandag = 0
+    const daysInMonth = new Date(current.getFullYear(), current.getMonth() + 1, 0).getDate();
+
+    const header = document.createElement('div');
+    header.className = 'calendar__header';
+    header.innerHTML = `<span>${monthName}</span><span>${daysInMonth} dagen</span>`;
+
+    const grid = document.createElement('div');
+    grid.className = 'calendar__grid';
+
+    WEEKDAYS.forEach((day) => {
+      const span = document.createElement('span');
+      span.textContent = day;
+      span.style.fontWeight = '600';
+      grid.appendChild(span);
+    });
+
+    for (let i = 0; i < startDay; i += 1) {
+      grid.appendChild(document.createElement('span'));
+    }
+
+    for (let day = 1; day <= daysInMonth; day += 1) {
+      const span = document.createElement('span');
+      span.textContent = day;
+      const isToday = day === current.getDate();
+      if (isToday) {
+        span.classList.add('is-today');
+      }
+      grid.appendChild(span);
+    }
+
+    this.root.innerHTML = '';
+    this.root.appendChild(header);
+    this.root.appendChild(grid);
+  }
+}

--- a/static/js/components/carouselControls.js
+++ b/static/js/components/carouselControls.js
@@ -1,0 +1,62 @@
+import { endpoints, post } from '../api.js';
+
+export class CarouselControls {
+  constructor(form, messageEl) {
+    this.form = form;
+    this.messageEl = messageEl;
+    this.minutesInput = form ? form.querySelector('input[name="minutes"]') : null;
+    this.startButton = form ? form.querySelector('[data-action="start"]') : null;
+    this.stopButton = form ? form.querySelector('[data-action="stop"]') : null;
+    this.init();
+  }
+
+  init() {
+    if (!this.form) return;
+    this.form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this.start();
+    });
+    if (this.stopButton) {
+      this.stopButton.addEventListener('click', () => this.stop());
+    }
+  }
+
+  async start() {
+    if (!this.minutesInput) return;
+    const minutes = Math.max(1, parseInt(this.minutesInput.value, 10) || 1);
+    try {
+      const data = await post(`${endpoints.carouselStart}?minutes=${encodeURIComponent(minutes)}`);
+      this.setMessage(data.ok ? 'Carousel gestart' : data.error || 'Onbekende fout');
+    } catch (error) {
+      this.setMessage(`Start mislukt: ${error.message}`);
+    }
+  }
+
+  async stop() {
+    try {
+      const data = await post(endpoints.carouselStop);
+      this.setMessage(data.ok ? 'Carousel gestopt' : data.error || 'Onbekende fout');
+    } catch (error) {
+      this.setMessage(`Stop mislukt: ${error.message}`);
+    }
+  }
+
+  sync(status) {
+    if (!status || !this.minutesInput) return;
+    if (typeof status.carousel?.minutes === 'number') {
+      this.minutesInput.value = status.carousel.minutes;
+    }
+    const running = Boolean(status.carousel?.running);
+    if (this.startButton) {
+      this.startButton.disabled = running;
+    }
+    if (this.stopButton) {
+      this.stopButton.disabled = !running;
+    }
+  }
+
+  setMessage(message) {
+    if (!this.messageEl) return;
+    this.messageEl.textContent = message;
+  }
+}

--- a/static/js/components/galleryManager.js
+++ b/static/js/components/galleryManager.js
@@ -1,0 +1,133 @@
+import { endpoints, getJSON, post } from '../api.js';
+
+function formatBytes(bytes) {
+  if (!bytes) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB'];
+  const i = Math.min(units.length - 1, Math.floor(Math.log(bytes) / Math.log(1024)));
+  const value = bytes / Math.pow(1024, i);
+  return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
+}
+
+function formatDate(value) {
+  try {
+    return new Date(value).toLocaleString();
+  } catch (error) {
+    return value;
+  }
+}
+
+export class GalleryManager {
+  constructor(gridEl, emptyStateEl, messageEl) {
+    this.gridEl = gridEl;
+    this.emptyStateEl = emptyStateEl;
+    this.messageEl = messageEl;
+    this.items = [];
+    this.currentFile = null;
+    this.gridEl?.addEventListener('click', (event) => this.onClick(event));
+  }
+
+  async load() {
+    if (!this.gridEl) return;
+    try {
+      const data = await getJSON(endpoints.images);
+      this.items = data.items || [];
+      this.render();
+    } catch (error) {
+      this.setMessage(`Kan lijst niet laden: ${error.message}`);
+    }
+  }
+
+  render() {
+    if (!this.gridEl) return;
+    this.gridEl.innerHTML = '';
+    if (!this.items.length) {
+      if (this.emptyStateEl) {
+        this.emptyStateEl.hidden = false;
+      }
+      document.dispatchEvent(new CustomEvent('gallery:updated', { detail: { count: 0 } }));
+      return;
+    }
+    if (this.emptyStateEl) {
+      this.emptyStateEl.hidden = true;
+    }
+    const fragment = document.createDocumentFragment();
+    this.items.forEach((item) => {
+      const card = document.createElement('article');
+      card.className = 'image-card';
+      card.dataset.file = item.name;
+      card.innerHTML = `
+        <a href="${item.url}" target="_blank" rel="noopener" class="image-card__link">
+          <img src="${item.url}" alt="${item.name}" class="image-card__thumb" loading="lazy">
+        </a>
+        <div class="image-card__meta">
+          <strong title="${item.name}">${item.name}</strong>
+          <span>${formatBytes(item.size)}</span>
+          <span>${formatDate(item.created_at)}</span>
+        </div>
+        <div class="image-card__actions">
+          <button type="button" class="action-button" data-action="display" data-file="${item.name}">Toon</button>
+          <button type="button" class="ghost-button" data-action="delete" data-file="${item.name}">Verwijder</button>
+        </div>
+      `;
+      fragment.appendChild(card);
+    });
+    this.gridEl.appendChild(fragment);
+    this.applyCurrentHighlight();
+    document.dispatchEvent(new CustomEvent('gallery:updated', { detail: { count: this.items.length } }));
+  }
+
+  markCurrent(fileName) {
+    this.currentFile = fileName;
+    this.applyCurrentHighlight();
+  }
+
+  applyCurrentHighlight() {
+    if (!this.gridEl) return;
+    [...this.gridEl.querySelectorAll('.image-card')].forEach((card) => {
+      card.classList.toggle('is-current', Boolean(this.currentFile) && card.dataset.file === this.currentFile);
+    });
+  }
+
+  async onClick(event) {
+    const button = event.target.closest('button[data-action]');
+    if (!button) return;
+    const file = button.dataset.file;
+    if (!file) return;
+    if (button.dataset.action === 'display') {
+      await this.display(file);
+    } else if (button.dataset.action === 'delete') {
+      if (confirm(`Weet je zeker dat je ${file} wilt verwijderen?`)) {
+        await this.remove(file);
+      }
+    }
+  }
+
+  async display(file) {
+    try {
+      const data = await post(`${endpoints.display}?file=${encodeURIComponent(file)}`);
+      this.setMessage(data.ok ? `${file} weergegeven` : data.error || 'Onbekende fout');
+    } catch (error) {
+      this.setMessage(`Tonen mislukt: ${error.message}`);
+    }
+  }
+
+  async remove(file) {
+    try {
+      const data = await post(`${endpoints.delete}?file=${encodeURIComponent(file)}`);
+      if (data.ok) {
+        this.setMessage(`${file} verwijderd`);
+        await this.load();
+      } else {
+        this.setMessage(data.error || 'Verwijderen mislukt');
+      }
+    } catch (error) {
+      this.setMessage(`Verwijderen mislukt: ${error.message}`);
+    }
+  }
+
+  setMessage(message) {
+    if (this.messageEl) {
+      this.messageEl.textContent = message;
+    }
+  }
+}

--- a/static/js/components/statusCard.js
+++ b/static/js/components/statusCard.js
@@ -1,0 +1,101 @@
+import { endpoints, getJSON } from '../api.js';
+
+function formatDuration(seconds) {
+  const s = Math.max(0, Math.round(seconds));
+  const minutes = Math.floor(s / 60);
+  const sec = s % 60;
+  if (minutes <= 0) {
+    return `${sec}s`;
+  }
+  return `${minutes}m ${sec.toString().padStart(2, '0')}s`;
+}
+
+export class StatusCard {
+  constructor(root) {
+    this.root = root;
+    this.timer = null;
+  }
+
+  start() {
+    if (!this.root) return;
+    this.refresh();
+    this.timer = setInterval(() => this.refresh(), 10000);
+  }
+
+  stop() {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+  }
+
+  async refresh() {
+    if (!this.root) return;
+    try {
+      const data = await getJSON(endpoints.status);
+      this.render(data);
+      document.dispatchEvent(new CustomEvent('status:update', { detail: data }));
+    } catch (error) {
+      this.root.innerHTML = `<div class="status-card__error">Status niet beschikbaar: ${error.message}</div>`;
+    }
+  }
+
+  render(data) {
+    const now = new Date();
+    const nextSwitch = data.carousel.next_switch_at ? new Date(data.carousel.next_switch_at) : null;
+    const totalSeconds = Math.max(0, (data.carousel.minutes || 0) * 60);
+    let secondsLeft = null;
+    let progress = null;
+
+    if (nextSwitch) {
+      secondsLeft = Math.round((nextSwitch.getTime() - now.getTime()) / 1000);
+    }
+
+    if (data.carousel.running && totalSeconds > 0 && typeof secondsLeft === 'number') {
+      const ratio = 1 - secondsLeft / totalSeconds;
+      progress = Math.max(0, Math.min(1, ratio));
+    }
+
+    const localNext = nextSwitch ? nextSwitch.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '—';
+    const resolution = Array.isArray(data.target_size) ? data.target_size.join(' × ') : '—';
+    const currentFile = data.carousel.current_file || '—';
+    const nextLabel = secondsLeft != null ? formatDuration(secondsLeft) : '—';
+
+    this.root.innerHTML = `
+      <div class="status-card__badges">
+        <span class="badge ${data.display_ready ? 'badge--ok' : 'badge--warn'}">
+          Display ${data.display_ready ? 'actief' : 'offline'}
+        </span>
+        <span class="badge ${data.carousel.running ? 'badge--ok' : 'badge--idle'}">
+          Carousel ${data.carousel.running ? 'actief' : 'gepauzeerd'}
+        </span>
+      </div>
+      <div class="status-card__metrics">
+        <dl>
+          <div>
+            <dt>Resolutie</dt>
+            <dd>${resolution}</dd>
+          </div>
+          <div>
+            <dt>Interval</dt>
+            <dd>${data.carousel.minutes || 0} minuten</dd>
+          </div>
+          <div>
+            <dt>Huidige foto</dt>
+            <dd title="${currentFile}">${currentFile}</dd>
+          </div>
+          <div>
+            <dt>Volgende wissel</dt>
+            <dd>${localNext}</dd>
+          </div>
+        </dl>
+      </div>
+      ${progress !== null ? `
+        <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="${Math.round(progress * 100)}">
+          <span class="progress__bar" style="width:${(progress * 100).toFixed(0)}%"></span>
+        </div>
+        <p class="status-card__note">Nog ${nextLabel} tot de volgende wissel</p>
+      ` : '<p class="status-card__note">Carousel staat stil</p>'}
+      <p class="status-card__timestamp">Bijgewerkt om ${now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}</p>
+    `;
+  }
+}

--- a/static/js/components/systemNotes.js
+++ b/static/js/components/systemNotes.js
@@ -1,0 +1,52 @@
+const BASE_NOTES = [
+  'Gebruik het dashboard op hetzelfde netwerk als de Raspberry Pi.',
+  'Uploads worden automatisch bijgesneden voor het Inky-scherm.'
+];
+
+export class SystemNotes {
+  constructor(listEl) {
+    this.listEl = listEl;
+    this.state = {
+      status: null,
+      galleryCount: null
+    };
+    this.render();
+  }
+
+  setStatus(status) {
+    this.state.status = status;
+    this.render();
+  }
+
+  setGalleryCount(count) {
+    this.state.galleryCount = count;
+    this.render();
+  }
+
+  render() {
+    if (!this.listEl) return;
+    const items = [...BASE_NOTES];
+
+    if (this.state.status) {
+      const { display_ready: displayReady, carousel } = this.state.status;
+      items.unshift(
+        displayReady ? 'Display gereed voor nieuwe afbeeldingen.' : 'Display niet gedetecteerd: controleer kabel en voeding.'
+      );
+      const nextSwitch = carousel?.next_switch_at
+        ? new Date(carousel.next_switch_at).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+        : '—';
+      items.push(`Carousel: ${carousel?.running ? 'actief' : 'gepauzeerd'} (interval ${carousel?.minutes || 0} min, volgende ${nextSwitch}).`);
+    }
+
+    if (typeof this.state.galleryCount === 'number') {
+      items.push(`Galerij bevat ${this.state.galleryCount} bestand(en).`);
+    }
+
+    this.listEl.innerHTML = '';
+    items.forEach((note) => {
+      const li = document.createElement('li');
+      li.textContent = note;
+      this.listEl.appendChild(li);
+    });
+  }
+}

--- a/static/js/components/uploadManager.js
+++ b/static/js/components/uploadManager.js
@@ -1,0 +1,44 @@
+import { endpoints, postForm } from '../api.js';
+
+export class UploadManager {
+  constructor(form, messageEl) {
+    this.form = form;
+    this.messageEl = messageEl;
+    this.init();
+  }
+
+  init() {
+    if (!this.form) return;
+    this.form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      this.upload();
+    });
+  }
+
+  async upload() {
+    if (!this.form) return;
+    const formData = new FormData(this.form);
+    try {
+      const data = await postForm(endpoints.upload, formData);
+      if (data.ok) {
+        const count = data.saved?.length || 0;
+        this.setMessage(`Upload voltooid: ${count} bestand(en)`);
+        this.form.reset();
+        document.dispatchEvent(new CustomEvent('gallery:refresh'));
+      } else if (data.saved?.length) {
+        this.setMessage(`Gedeeltelijk gelukt: ${data.saved.length} opgeslagen, ${data.errors?.length || 0} fouten`);
+        document.dispatchEvent(new CustomEvent('gallery:refresh'));
+      } else {
+        this.setMessage(data.error || 'Upload mislukt');
+      }
+    } catch (error) {
+      this.setMessage(`Upload mislukt: ${error.message}`);
+    }
+  }
+
+  setMessage(message) {
+    if (this.messageEl) {
+      this.messageEl.textContent = message;
+    }
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html lang="nl">
+<head>
+  <meta charset="utf-8">
+  <title>Inky Photoframe Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="/static/css/main.css">
+</head>
+<body>
+  <div class="dashboard">
+    <header class="dashboard__header">
+      <div>
+        <h1>Inky Photoframe</h1>
+        <p class="dashboard__subtitle">Beheer en status voor jouw e-ink fotoframe</p>
+      </div>
+      <div class="dashboard__clock" id="clock" aria-live="polite">--:--</div>
+    </header>
+
+    <main class="dashboard__main">
+      <section class="panel panel--wide" aria-labelledby="status-heading">
+        <div class="panel__head">
+          <h2 id="status-heading">Systeemstatus</h2>
+          <button type="button" class="ghost-button" id="forceStatus">Ververs</button>
+        </div>
+        <div id="statusCard" class="status-card" aria-live="polite">Status laden…</div>
+      </section>
+
+      <section class="panel" aria-labelledby="carousel-heading">
+        <div class="panel__head">
+          <h2 id="carousel-heading">Carousel</h2>
+        </div>
+        <form id="carouselForm" class="form-grid">
+          <label class="form-grid__field">
+            <span>Minuten per foto</span>
+            <input id="minutesInput" name="minutes" type="number" min="1" step="1" value="5" inputmode="numeric">
+          </label>
+          <div class="button-row">
+            <button type="submit" class="action-button" data-action="start">Start</button>
+            <button type="button" class="ghost-button" data-action="stop">Stop</button>
+          </div>
+        </form>
+        <div id="carouselMessage" class="panel__messages" role="status"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="upload-heading">
+        <div class="panel__head">
+          <h2 id="upload-heading">Fotobeheer</h2>
+        </div>
+        <form id="uploadForm" class="upload" enctype="multipart/form-data">
+          <label class="upload__field">
+            <span>Bestanden toevoegen</span>
+            <input type="file" name="file" accept="image/*" multiple required>
+          </label>
+          <button type="submit" class="action-button">Uploaden</button>
+        </form>
+        <div id="uploadMessage" class="panel__messages" role="status"></div>
+      </section>
+
+      <section class="panel panel--gallery" aria-labelledby="gallery-heading">
+        <div class="panel__head">
+          <h2 id="gallery-heading">Galerij</h2>
+          <div class="panel__tools">
+            <button type="button" class="ghost-button" id="refreshGallery">Ververs lijst</button>
+          </div>
+        </div>
+        <div id="galleryMessage" class="panel__messages" role="status"></div>
+        <div id="imageGrid" class="image-grid" aria-live="polite"></div>
+        <p id="galleryEmpty" class="empty-state" hidden>Geen afbeeldingen gevonden. Upload een nieuwe serie om te starten.</p>
+      </section>
+
+      <section class="panel" aria-labelledby="calendar-heading">
+        <div class="panel__head">
+          <h2 id="calendar-heading">Kalender</h2>
+        </div>
+        <div id="calendarWidget" class="calendar"></div>
+      </section>
+
+      <section class="panel" aria-labelledby="notes-heading">
+        <div class="panel__head">
+          <h2 id="notes-heading">Notities &amp; hints</h2>
+        </div>
+        <ul id="systemNotes" class="notes-list" aria-live="polite">
+          <li>Gebruik het dashboard op hetzelfde netwerk als de Raspberry Pi.</li>
+          <li>Uploads worden automatisch bijgesneden voor het Inky-scherm.</li>
+        </ul>
+      </section>
+    </main>
+
+    <footer class="dashboard__footer">
+      <span>Versie 1.3</span>
+      <span>Inky Photoframe &mdash; geoptimaliseerd voor e-ink schermen</span>
+    </footer>
+  </div>
+
+  <script type="module" src="/static/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the inline HTML dashboard with a templated layout that includes status, carousel, gallery, calendar, and notes panels
- add a lightweight CSS theme and modular JavaScript components for status polling, carousel control, uploads, and gallery updates
- expose static assets via the server with cache headers and document the new structure and caching behaviour in the README

## Testing
- python -m compileall photo.py

------
https://chatgpt.com/codex/tasks/task_e_68d015e32e74832c93c030ca2a225322