### PR TITLE
Add cache backends and integrate with app state

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -12,6 +12,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
+from . import cache
 from .inky import display as inky_display
 from .models.config import RuntimeConfig
 from .storage.files import ensure_image_dir
@@ -62,10 +63,19 @@ class ServerConfig:
     admin_token: Optional[str] = None
     rate_limit_per_minute: int = DEFAULT_ADMIN_RATE_LIMIT
     log_path: Optional[Path] = None
+    cache_config_path: Optional[Path] = None
 
 
 @dataclass
 class AppState:
+    """Container for FastAPI state shared across request handlers.
+
+    The caches are configured via a YAML file (``cache.yaml`` by default).
+    ``cache_settings`` exposes the normalised configuration while
+    ``caches`` provides a convenience API that bundles the in-memory, file
+    and SQLite backends for widget render results.
+    """
+
     config: ServerConfig
     templates: Jinja2Templates
     image_dir: Path
@@ -74,6 +84,9 @@ class AppState:
     runtime_config: RuntimeConfig
     rate_limiter: RateLimiter
     widget_registry: WidgetRegistry
+    cache_config_path: Path
+    cache_settings: cache.CacheSettings
+    caches: cache.CacheManager
     last_rendered: Optional[str] = None
     _lock: threading.Lock = field(default_factory=threading.Lock)
 
@@ -82,6 +95,8 @@ class AppState:
         return self.config.log_path or (self.image_dir / "photoframe.log")
 
     def set_runtime_config(self, config: RuntimeConfig) -> None:
+        """Persist a new :class:`RuntimeConfig` to disk."""
+
         with self._lock:
             self.runtime_config = config
             payload = json.dumps(_model_dump(config), indent=2, ensure_ascii=False)
@@ -115,6 +130,12 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
     runtime_config_path = config.image_dir / "config.json"
     runtime_config = _load_runtime_config(runtime_config_path)
 
+    cache_config_path = config.cache_config_path or (config.image_dir / "cache.yaml")
+    if not cache_config_path.is_absolute():
+        cache_config_path = (config.image_dir / cache_config_path).resolve()
+    cache_settings = cache.load_cache_settings(cache_config_path, base_dir=config.image_dir)
+    cache_manager = cache.create_cache_manager(cache_settings)
+
     limiter = RateLimiter(limit=config.rate_limit_per_minute, window_seconds=60)
     templates = Jinja2Templates(directory=str(template_dir))
     registry = create_default_registry()
@@ -133,6 +154,9 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         runtime_config=runtime_config,
         rate_limiter=limiter,
         widget_registry=registry,
+        cache_config_path=cache_config_path,
+        cache_settings=cache_settings,
+        caches=cache_manager,
     )
 
     @app.get("/", response_class=HTMLResponse)

--- a/server/cache/__init__.py
+++ b/server/cache/__init__.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional
+
+from .files import FilesCache
+from .memory import MemoryCache
+from .models import CacheEntry, CacheSettings
+from .sqlite import SqliteCache
+
+
+def _read_yaml(path: Path) -> Mapping[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    try:
+        import yaml  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency
+        if not text.strip():
+            return {}
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:  # pragma: no cover - error path
+            raise RuntimeError(f"Cannot parse cache configuration {path!s}: install PyYAML") from exc
+    else:
+        data = yaml.safe_load(text)  # type: ignore[assignment]
+    if data is None:
+        return {}
+    if not isinstance(data, Mapping):
+        raise TypeError(f"Cache configuration must be a mapping, got {type(data).__name__}")
+    return data
+
+
+def load_cache_settings(config_path: Path, base_dir: Path) -> CacheSettings:
+    """Load cache settings from ``config_path`` or return defaults."""
+
+    if not config_path.is_absolute():
+        config_path = (base_dir / config_path).resolve()
+    if config_path.exists():
+        data = _read_yaml(config_path)
+        config_dir = config_path.parent
+    else:
+        data = {}
+        config_dir = base_dir
+    return CacheSettings.from_mapping(data, base_dir=base_dir, config_dir=config_dir)
+
+
+@dataclass(slots=True)
+class CacheManager:
+    """High-level convenience wrapper combining all cache backends."""
+
+    memory: Optional[MemoryCache] = None
+    files: Optional[FilesCache] = None
+    sqlite: Optional[SqliteCache] = None
+
+    def store(
+        self,
+        namespace: str,
+        key: str,
+        payload: bytes,
+        ttl: Optional[int] = None,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+    ) -> Optional[CacheEntry]:
+        """Store a payload across the configured caches."""
+
+        entry: Optional[CacheEntry] = None
+        if self.memory and self.memory.enabled:
+            entry = self.memory.store(namespace, key, payload, ttl=ttl, metadata=metadata)
+        if self.sqlite and self.sqlite.enabled:
+            entry = self.sqlite.store(namespace, key, payload, ttl=ttl, metadata=metadata)
+        return entry
+
+    def store_png(
+        self,
+        namespace: str,
+        key: str,
+        payload: bytes,
+        ttl: Optional[int] = None,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+    ) -> Optional[CacheEntry]:
+        """Store a PNG payload in memory, on disk and optionally SQLite."""
+
+        meta = dict(metadata or {})
+        if self.files and self.files.enabled:
+            file_entry = self.files.store(namespace, key, payload, ttl=ttl, metadata=meta)
+            meta.setdefault("file_path", str(file_entry.payload))
+        entry = None
+        if self.sqlite and self.sqlite.enabled:
+            entry = self.sqlite.store(namespace, key, payload, ttl=ttl, metadata=meta)
+        if self.memory and self.memory.enabled:
+            entry = self.memory.store(namespace, key, payload, ttl=ttl, metadata=meta)
+        return entry
+
+    def get(self, namespace: str, key: str) -> Optional[CacheEntry]:
+        """Return a cached payload if available."""
+
+        if self.memory and self.memory.enabled:
+            entry = self.memory.get(namespace, key)
+            if entry is not None:
+                return entry
+        if self.sqlite and self.sqlite.enabled:
+            entry = self.sqlite.get(namespace, key)
+            if entry is not None and self.memory and self.memory.enabled:
+                self.memory.store_entry(entry)
+                return entry
+            if entry is not None:
+                return entry
+        return None
+
+    def get_png_bytes(self, namespace: str, key: str) -> Optional[bytes]:
+        """Return PNG bytes from cache, falling back to disk when required."""
+
+        entry = self.get(namespace, key)
+        if entry is not None:
+            payload = entry.payload
+            if isinstance(payload, (bytes, bytearray, memoryview)):
+                return bytes(payload)
+        if self.files and self.files.enabled:
+            file_entry = self.files.get(namespace, key)
+            if file_entry is None:
+                return None
+            path = file_entry.payload
+            if not isinstance(path, Path):
+                return None
+            try:
+                data = path.read_bytes()
+            except FileNotFoundError:
+                self.files.invalidate(namespace, key)
+                return None
+            if self.memory and self.memory.enabled:
+                memory_entry = CacheEntry(
+                    namespace=namespace,
+                    key=key,
+                    payload=data,
+                    metadata=dict(file_entry.metadata),
+                    created_at=file_entry.created_at,
+                    expires_at=file_entry.expires_at,
+                )
+                self.memory.store_entry(memory_entry)
+            return data
+        return None
+
+    def invalidate(self, namespace: str, key: Optional[str] = None) -> None:
+        """Invalidate all cache layers for a namespace/key."""
+
+        if self.memory and self.memory.enabled:
+            self.memory.invalidate(namespace, key)
+        if self.sqlite and self.sqlite.enabled:
+            self.sqlite.invalidate(namespace, key)
+        if self.files and self.files.enabled:
+            self.files.invalidate(namespace, key)
+
+    def cleanup(self) -> dict[str, int]:
+        """Run cleanup on all caches and return a purge summary."""
+
+        summary: dict[str, int] = {}
+        if self.memory and self.memory.enabled:
+            summary["memory"] = self.memory.cleanup()
+        if self.sqlite and self.sqlite.enabled:
+            summary["sqlite"] = self.sqlite.cleanup()
+        if self.files and self.files.enabled:
+            summary["files"] = self.files.cleanup()
+        return summary
+
+
+def create_cache_manager(settings: CacheSettings) -> CacheManager:
+    """Instantiate caches based on the provided :class:`CacheSettings`."""
+
+    memory = MemoryCache(settings.memory) if settings.memory.enabled else None
+    files = FilesCache(settings.files) if settings.files.enabled else None
+    sqlite = SqliteCache(settings.sqlite) if settings.sqlite.enabled else None
+    return CacheManager(memory=memory, files=files, sqlite=sqlite)
+
+
+__all__ = [
+    "CacheEntry",
+    "CacheManager",
+    "CacheSettings",
+    "create_cache_manager",
+    "load_cache_settings",
+]

--- a/server/cache/files.py
+++ b/server/cache/files.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import threading
+import time
+from pathlib import Path
+from typing import Any, MutableMapping, Optional
+
+from .models import CacheEntry, FilesCacheConfig
+
+
+class FilesCache:
+    """On-disk cache storing PNG payloads segregated by namespace."""
+
+    def __init__(self, config: FilesCacheConfig) -> None:
+        self._enabled = bool(config.enabled and config.directory)
+        self._directory = config.directory if config.directory else Path(".")
+        self._default_ttl = config.default_ttl
+        self._lock = threading.Lock()
+        if self._enabled:
+            self._directory.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def _expiry(self, ttl: Optional[int], now: float) -> Optional[float]:
+        if ttl is None:
+            ttl = self._default_ttl
+        if ttl is None or ttl <= 0:
+            return None
+        return now + ttl
+
+    def _slugify(self, name: str) -> str:
+        slug = re.sub(r"\s+", "-", name.strip().lower())
+        slug = re.sub(r"[^a-z0-9._-]", "-", slug)
+        return slug or "default"
+
+    def _filename(self, key: str) -> str:
+        slug = self._slugify(key)[:40]
+        digest = hashlib.sha1(key.encode("utf-8")).hexdigest()[:12]
+        return f"{slug}-{digest}.png"
+
+    def _path_for(self, namespace: str, key: str) -> Path:
+        ns_dir = self._directory / self._slugify(namespace)
+        return ns_dir / self._filename(key)
+
+    def store(
+        self,
+        namespace: str,
+        key: str,
+        payload: bytes,
+        ttl: Optional[int] = None,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+    ) -> CacheEntry:
+        """Persist a PNG payload and return a :class:`CacheEntry`."""
+
+        if not self.enabled:
+            raise RuntimeError("FilesCache is disabled")
+        now = time.time()
+        target = self._path_for(namespace, key)
+        with self._lock:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(payload)
+            meta = {
+                "namespace": namespace,
+                "key": key,
+                "created_at": now,
+                "expires_at": self._expiry(ttl, now),
+                "metadata": dict(metadata or {}),
+            }
+            meta_path = Path(str(target) + ".json")
+            meta_path.write_text(json.dumps(meta), encoding="utf-8")
+        return CacheEntry(
+            namespace=namespace,
+            key=key,
+            payload=target,
+            metadata=dict(metadata or {}),
+            created_at=now,
+            expires_at=meta["expires_at"],
+        )
+
+    def get(self, namespace: str, key: str) -> Optional[CacheEntry]:
+        """Return a :class:`CacheEntry` if present and not expired."""
+
+        if not self.enabled:
+            return None
+        target = self._path_for(namespace, key)
+        meta_path = Path(str(target) + ".json")
+        if not target.exists() or not meta_path.exists():
+            return None
+        try:
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            meta = {
+                "created_at": target.stat().st_mtime,
+                "expires_at": None,
+                "metadata": {},
+            }
+        expires_at = meta.get("expires_at")
+        if expires_at is not None and time.time() >= float(expires_at):
+            self.invalidate(namespace, key)
+            return None
+        return CacheEntry(
+            namespace=namespace,
+            key=key,
+            payload=target,
+            metadata=dict(meta.get("metadata") or {}),
+            created_at=float(meta.get("created_at", target.stat().st_mtime)),
+            expires_at=float(expires_at) if expires_at is not None else None,
+        )
+
+    def read(self, namespace: str, key: str) -> Optional[bytes]:
+        """Return the raw PNG payload if still cached."""
+
+        entry = self.get(namespace, key)
+        if entry is None:
+            return None
+        path: Path = entry.payload  # type: ignore[assignment]
+        try:
+            return path.read_bytes()
+        except FileNotFoundError:
+            return None
+
+    def invalidate(self, namespace: str, key: Optional[str] = None) -> int:
+        """Remove cached files for the given namespace/key."""
+
+        if not self.enabled:
+            return 0
+        removed = 0
+        with self._lock:
+            if key is not None:
+                target = self._path_for(namespace, key)
+                removed += self._unlink(target)
+                removed += self._unlink(Path(str(target) + ".json"))
+            else:
+                ns_dir = self._directory / self._slugify(namespace)
+                if ns_dir.exists():
+                    for child in ns_dir.glob("*"):
+                        removed += self._unlink(child)
+                    try:
+                        ns_dir.rmdir()
+                    except OSError:
+                        pass
+        return removed
+
+    def cleanup(self) -> int:
+        """Purge expired entries from disk."""
+
+        if not self.enabled:
+            return 0
+        purged = 0
+        now = time.time()
+        for meta_path in self._directory.glob("**/*.png.json"):
+            try:
+                meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                meta = {}
+            expires_at = meta.get("expires_at")
+            if expires_at is not None and now >= float(expires_at):
+                png_path = Path(str(meta_path)[:-5])  # strip .json
+                purged += self._unlink(png_path)
+                purged += self._unlink(meta_path)
+        return purged
+
+    def _unlink(self, path: Path) -> int:
+        try:
+            path.unlink()
+            return 1
+        except FileNotFoundError:
+            return 0
+
+
+__all__ = ["FilesCache"]

--- a/server/cache/memory.py
+++ b/server/cache/memory.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from typing import Any, MutableMapping, Optional
+
+from .models import CacheEntry, MemoryCacheConfig
+
+
+class MemoryCache:
+    """An in-memory LRU cache with TTL-aware entries."""
+
+    def __init__(self, config: MemoryCacheConfig) -> None:
+        self._enabled = config.enabled and config.max_items > 0
+        self._max_items = max(0, config.max_items)
+        self._default_ttl = config.default_ttl
+        self._entries: "OrderedDict[tuple[str, str], CacheEntry]" = OrderedDict()
+        self._lock = threading.Lock()
+
+    @property
+    def enabled(self) -> bool:
+        """Return ``True`` when the cache actively stores items."""
+
+        return self._enabled
+
+    def _expiry(self, ttl: Optional[int], now: float) -> Optional[float]:
+        if ttl is None:
+            ttl = self._default_ttl
+        if ttl is None or ttl <= 0:
+            return None
+        return now + ttl
+
+    def store(
+        self,
+        namespace: str,
+        key: str,
+        payload: Any,
+        ttl: Optional[int] = None,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+    ) -> CacheEntry:
+        """Store an item and return the resulting :class:`CacheEntry`."""
+
+        now = time.time()
+        entry = CacheEntry(
+            namespace=namespace,
+            key=key,
+            payload=payload,
+            metadata=dict(metadata or {}),
+            created_at=now,
+            expires_at=self._expiry(ttl, now),
+        )
+        return self.store_entry(entry)
+
+    def store_entry(self, entry: CacheEntry) -> CacheEntry:
+        """Insert an existing :class:`CacheEntry` into the cache."""
+
+        if not self.enabled:
+            return entry
+        with self._lock:
+            cache_key = (entry.namespace, entry.key)
+            self._entries[cache_key] = entry
+            self._entries.move_to_end(cache_key)
+            self._evict_unlocked()
+        return entry
+
+    def get(self, namespace: str, key: str) -> Optional[CacheEntry]:
+        """Return a cached entry or ``None`` when unavailable/expired."""
+
+        if not self.enabled:
+            return None
+        cache_key = (namespace, key)
+        with self._lock:
+            entry = self._entries.get(cache_key)
+            if entry is None:
+                return None
+            if entry.is_expired():
+                self._entries.pop(cache_key, None)
+                return None
+            # promote to most recently used
+            self._entries.move_to_end(cache_key)
+            return entry
+
+    def invalidate(self, namespace: str, key: Optional[str] = None) -> int:
+        """Invalidate entries for a namespace and optional key.
+
+        Returns the number of evicted entries.
+        """
+
+        if not self.enabled:
+            return 0
+        removed = 0
+        with self._lock:
+            if key is not None:
+                cache_key = (namespace, key)
+                if cache_key in self._entries:
+                    self._entries.pop(cache_key, None)
+                    removed = 1
+            else:
+                to_delete = [k for k in self._entries if k[0] == namespace]
+                for cache_key in to_delete:
+                    self._entries.pop(cache_key, None)
+                removed = len(to_delete)
+        return removed
+
+    def cleanup(self) -> int:
+        """Remove expired entries and return the number of purged items."""
+
+        if not self.enabled:
+            return 0
+        purged = 0
+        now = time.time()
+        with self._lock:
+            to_delete = [k for k, entry in self._entries.items() if entry.is_expired(now)]
+            for cache_key in to_delete:
+                self._entries.pop(cache_key, None)
+            purged = len(to_delete)
+        return purged
+
+    def _evict_unlocked(self) -> None:
+        if self._max_items <= 0:
+            self._entries.clear()
+            return
+        while len(self._entries) > self._max_items:
+            self._entries.popitem(last=False)
+
+
+__all__ = ["MemoryCache"]

--- a/server/cache/models.py
+++ b/server/cache/models.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Mapping, MutableMapping, Optional
+
+
+@dataclass(slots=True)
+class CacheEntry:
+    """Single cache entry stored by one of the cache backends."""
+
+    namespace: str
+    key: str
+    payload: Any
+    metadata: MutableMapping[str, Any]
+    created_at: float
+    expires_at: Optional[float]
+
+    def is_expired(self, now: Optional[float] = None) -> bool:
+        """Return ``True`` if the entry has expired."""
+
+        if self.expires_at is None:
+            return False
+        if now is None:
+            import time
+
+            now = time.time()
+        return now >= self.expires_at
+
+
+@dataclass(slots=True)
+class MemoryCacheConfig:
+    enabled: bool = True
+    max_items: int = 128
+    default_ttl: Optional[int] = 300
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any] | None) -> "MemoryCacheConfig":
+        payload = dict(data or {})
+        enabled = bool(payload.get("enabled", True))
+        max_items = int(payload.get("max_items", 128))
+        default_ttl = payload.get("default_ttl", payload.get("ttl", 300))
+        if default_ttl is not None:
+            default_ttl = int(default_ttl)
+        return cls(enabled=enabled, max_items=max_items, default_ttl=default_ttl)
+
+
+@dataclass(slots=True)
+class FilesCacheConfig:
+    enabled: bool = True
+    directory: Path | None = None
+    default_ttl: Optional[int] = 900
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any] | None,
+        base_dir: Path,
+        config_dir: Path,
+    ) -> "FilesCacheConfig":
+        payload = dict(data or {})
+        enabled = bool(payload.get("enabled", True))
+        directory_value = payload.get("directory")
+        directory: Path | None
+        if directory_value:
+            directory = Path(directory_value)
+            if not directory.is_absolute():
+                # Relative paths are resolved against the YAML config location first,
+                # and fall back to the image directory.
+                directory = (config_dir / directory).resolve()
+        else:
+            directory = (base_dir / "cache" / "png").resolve()
+        default_ttl = payload.get("default_ttl", payload.get("ttl", 900))
+        if default_ttl is not None:
+            default_ttl = int(default_ttl)
+        return cls(enabled=enabled, directory=directory, default_ttl=default_ttl)
+
+
+@dataclass(slots=True)
+class SqliteCacheConfig:
+    enabled: bool = True
+    path: Path | None = None
+    default_ttl: Optional[int] = 86400
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any] | None,
+        base_dir: Path,
+        config_dir: Path,
+    ) -> "SqliteCacheConfig":
+        payload = dict(data or {})
+        enabled = bool(payload.get("enabled", True))
+        path_value = payload.get("path") or payload.get("file")
+        path: Path | None
+        if path_value:
+            path = Path(path_value)
+            if not path.is_absolute():
+                path = (config_dir / path).resolve()
+        else:
+            path = (base_dir / "cache" / "metadata.sqlite").resolve()
+        default_ttl = payload.get("default_ttl", payload.get("ttl", 86400))
+        if default_ttl is not None:
+            default_ttl = int(default_ttl)
+        return cls(enabled=enabled, path=path, default_ttl=default_ttl)
+
+
+@dataclass(slots=True)
+class CacheSettings:
+    memory: MemoryCacheConfig
+    files: FilesCacheConfig
+    sqlite: SqliteCacheConfig
+
+    @classmethod
+    def from_mapping(
+        cls,
+        data: Mapping[str, Any] | None,
+        base_dir: Path,
+        config_dir: Path,
+    ) -> "CacheSettings":
+        payload = dict(data or {})
+        memory_cfg = MemoryCacheConfig.from_mapping(payload.get("memory"))
+        files_cfg = FilesCacheConfig.from_mapping(payload.get("files"), base_dir, config_dir)
+        sqlite_cfg = SqliteCacheConfig.from_mapping(payload.get("sqlite"), base_dir, config_dir)
+        return cls(memory=memory_cfg, files=files_cfg, sqlite=sqlite_cfg)
+
+
+__all__ = [
+    "CacheEntry",
+    "CacheSettings",
+    "FilesCacheConfig",
+    "MemoryCacheConfig",
+    "SqliteCacheConfig",
+]

--- a/server/cache/sqlite.py
+++ b/server/cache/sqlite.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, MutableMapping, Optional
+
+from .models import CacheEntry, SqliteCacheConfig
+
+
+class SqliteCache:
+    """SQLite-backed cache storing payloads alongside metadata."""
+
+    def __init__(self, config: SqliteCacheConfig) -> None:
+        self._enabled = bool(config.enabled and config.path)
+        self._path = config.path if config.path else Path(":memory:")
+        self._default_ttl = config.default_ttl
+        self._lock = threading.Lock()
+        if self._enabled:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._initialise()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(str(self._path), detect_types=sqlite3.PARSE_DECLTYPES, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _initialise(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache_entries (
+                    namespace TEXT NOT NULL,
+                    cache_key TEXT NOT NULL,
+                    payload BLOB NOT NULL,
+                    metadata TEXT,
+                    created_at REAL NOT NULL,
+                    expires_at REAL,
+                    PRIMARY KEY(namespace, cache_key)
+                )
+                """
+            )
+            conn.commit()
+
+    def _expiry(self, ttl: Optional[int], now: float) -> Optional[float]:
+        if ttl is None:
+            ttl = self._default_ttl
+        if ttl is None or ttl <= 0:
+            return None
+        return now + ttl
+
+    def store(
+        self,
+        namespace: str,
+        key: str,
+        payload: bytes,
+        ttl: Optional[int] = None,
+        metadata: Optional[MutableMapping[str, Any]] = None,
+    ) -> CacheEntry:
+        """Persist a payload and return a :class:`CacheEntry`."""
+
+        if not self.enabled:
+            raise RuntimeError("SqliteCache is disabled")
+        now = time.time()
+        expires_at = self._expiry(ttl, now)
+        meta_text = json.dumps(dict(metadata or {}))
+        with self._lock:
+            with self._connect() as conn:
+                conn.execute(
+                    """
+                    INSERT OR REPLACE INTO cache_entries(namespace, cache_key, payload, metadata, created_at, expires_at)
+                    VALUES(?, ?, ?, ?, ?, ?)
+                    """,
+                    (namespace, key, sqlite3.Binary(payload), meta_text, now, expires_at),
+                )
+                conn.commit()
+        return CacheEntry(
+            namespace=namespace,
+            key=key,
+            payload=payload,
+            metadata=json.loads(meta_text) if meta_text else {},
+            created_at=now,
+            expires_at=expires_at,
+        )
+
+    def get(self, namespace: str, key: str) -> Optional[CacheEntry]:
+        """Return a cached payload or ``None`` when unavailable."""
+
+        if not self.enabled:
+            return None
+        with self._lock:
+            with self._connect() as conn:
+                row = conn.execute(
+                    "SELECT payload, metadata, created_at, expires_at FROM cache_entries WHERE namespace=? AND cache_key=?",
+                    (namespace, key),
+                ).fetchone()
+        if row is None:
+            return None
+        expires_at = row["expires_at"]
+        if expires_at is not None and time.time() >= float(expires_at):
+            self.invalidate(namespace, key)
+            return None
+        metadata = json.loads(row["metadata"] or "{}")
+        return CacheEntry(
+            namespace=namespace,
+            key=key,
+            payload=row["payload"],
+            metadata=metadata,
+            created_at=float(row["created_at"]),
+            expires_at=float(expires_at) if expires_at is not None else None,
+        )
+
+    def read(self, namespace: str, key: str) -> Optional[bytes]:
+        """Return the raw payload without metadata lookups."""
+
+        entry = self.get(namespace, key)
+        if entry is None:
+            return None
+        return bytes(entry.payload)
+
+    def invalidate(self, namespace: str, key: Optional[str] = None) -> int:
+        """Remove cached entries and return the number of affected rows."""
+
+        if not self.enabled:
+            return 0
+        with self._lock:
+            with self._connect() as conn:
+                if key is None:
+                    cursor = conn.execute("DELETE FROM cache_entries WHERE namespace=?", (namespace,))
+                else:
+                    cursor = conn.execute(
+                        "DELETE FROM cache_entries WHERE namespace=? AND cache_key=?",
+                        (namespace, key),
+                    )
+                conn.commit()
+                return cursor.rowcount or 0
+
+    def cleanup(self) -> int:
+        """Purge expired entries and return the number of removed records."""
+
+        if not self.enabled:
+            return 0
+        with self._lock:
+            with self._connect() as conn:
+                cursor = conn.execute("DELETE FROM cache_entries WHERE expires_at IS NOT NULL AND expires_at <= ?", (time.time(),))
+                conn.commit()
+                return cursor.rowcount or 0
+
+
+__all__ = ["SqliteCache"]


### PR DESCRIPTION
## Summary
- add a server.cache package that provides SQLite, file and in-memory cache backends with TTL, invalidation and namespace support
- expose the cache manager and resolved YAML configuration on `AppState` and load settings during application startup

## Testing
- python -m compileall server

------
https://chatgpt.com/codex/tasks/task_e_68d0f93fc1a4832caa2f37a150d30250