### PR TITLE
Add renderer pipeline with theming and PNG output

### DIFF
--- a/server/renderer/__init__.py
+++ b/server/renderer/__init__.py
@@ -1,0 +1,13 @@
+"""Rendering pipeline and helpers for the photoframe server."""
+
+from .pipeline import PipelineRequest, PipelineResult, RendererPipeline
+from .theme import Theme, get_theme, list_themes
+
+__all__ = [
+    "PipelineRequest",
+    "PipelineResult",
+    "RendererPipeline",
+    "Theme",
+    "get_theme",
+    "list_themes",
+]

--- a/server/renderer/layout.py
+++ b/server/renderer/layout.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Callable, Dict, Iterable, List, Tuple
+
+from PIL import Image, ImageOps
+
+from .surface import Surface
+from .theme import Theme
+
+
+@dataclass
+class LayoutContent:
+    title: str = ""
+    subtitle: str = ""
+    details: List[str] = field(default_factory=list)
+    footer: str = ""
+
+
+LayoutFunc = Callable[[Surface, Image.Image, Theme, LayoutContent, bool], Image.Image]
+
+
+GUTTER_RATIO = 0.05
+TEXT_LINE_SPACING = 6
+
+
+def _scaled_font(surface: Surface, factor: float) -> int:
+    width, height = surface.image.size
+    base = min(width, height)
+    return max(16, int(base * factor))
+
+
+def _render_single(surface: Surface, content: Image.Image, theme: Theme, meta: LayoutContent, separators: bool) -> Image.Image:
+    target_size = surface.image.size
+    scaled = ImageOps.contain(content, target_size, Image.Resampling.LANCZOS)
+    offset = ((target_size[0] - scaled.width) // 2, (target_size[1] - scaled.height) // 2)
+    surface.paste(scaled, offset)
+
+    if meta.title or meta.subtitle or meta.footer:
+        width, height = target_size
+        panel_height = max(int(height * 0.22), 96)
+        panel_top = height - panel_height
+        surface.rectangle((0, panel_top, width, height), fill=theme.background)
+        padding = int(width * GUTTER_RATIO)
+        if separators:
+            surface.line(((padding, panel_top), (width - padding, panel_top)), fill=theme.separator, width=2)
+        cursor_y = panel_top + int(panel_height * 0.18)
+        title_font = surface.fonts.get(size=_scaled_font(surface, 0.09))
+        subtitle_font = surface.fonts.get(size=_scaled_font(surface, 0.05))
+        footer_font = surface.fonts.get(size=_scaled_font(surface, 0.045))
+        if meta.title:
+            surface.text((padding, cursor_y), meta.title, font=title_font, fill=theme.foreground)
+            _, title_h = surface.text_size(meta.title, font=title_font)
+            cursor_y += title_h + TEXT_LINE_SPACING
+        if meta.subtitle:
+            surface.text((padding, cursor_y), meta.subtitle, font=subtitle_font, fill=theme.muted)
+            _, sub_h = surface.text_size(meta.subtitle, font=subtitle_font)
+            cursor_y += sub_h + TEXT_LINE_SPACING
+        if meta.footer:
+            footer_y = height - padding - surface.text_size(meta.footer, font=footer_font)[1]
+            surface.text((padding, footer_y), meta.footer, font=footer_font, fill=theme.accent)
+
+    return surface.image
+
+
+def _render_two_column(surface: Surface, content: Image.Image, theme: Theme, meta: LayoutContent, separators: bool) -> Image.Image:
+    width, height = surface.image.size
+    gutter = int(width * GUTTER_RATIO)
+    left_width = int(width * 0.58)
+    image_height = height - 2 * gutter
+    scaled = ImageOps.fit(content, (left_width, image_height), Image.Resampling.LANCZOS)
+    surface.paste(scaled, (gutter, gutter))
+
+    column_x = gutter + left_width + gutter
+    if separators:
+        surface.line(((column_x - gutter // 2, gutter), (column_x - gutter // 2, height - gutter)), fill=theme.separator, width=3)
+
+    title_font = surface.fonts.get(size=_scaled_font(surface, 0.09))
+    body_font = surface.fonts.get(size=_scaled_font(surface, 0.05))
+    footer_font = surface.fonts.get(size=_scaled_font(surface, 0.045))
+
+    cursor_y = gutter
+    if meta.title:
+        surface.text((column_x, cursor_y), meta.title, font=title_font, fill=theme.foreground)
+        _, title_h = surface.text_size(meta.title, font=title_font)
+        cursor_y += title_h + TEXT_LINE_SPACING
+    if meta.subtitle:
+        surface.text((column_x, cursor_y), meta.subtitle, font=body_font, fill=theme.accent)
+        _, sub_h = surface.text_size(meta.subtitle, font=body_font)
+        cursor_y += sub_h + TEXT_LINE_SPACING
+    if meta.details:
+        cursor_y += surface.multiline_text((column_x, cursor_y), meta.details, font=body_font, fill=theme.muted, line_spacing=TEXT_LINE_SPACING)
+    if meta.footer:
+        footer_y = height - gutter - surface.text_size(meta.footer, font=footer_font)[1]
+        surface.text((column_x, footer_y), meta.footer, font=footer_font, fill=theme.separator)
+
+    return surface.image
+
+
+def _render_hero(surface: Surface, content: Image.Image, theme: Theme, meta: LayoutContent, separators: bool) -> Image.Image:
+    width, height = surface.image.size
+    hero_height = int(height * 0.65)
+    scaled = ImageOps.fit(content, (width, hero_height), Image.Resampling.LANCZOS)
+    surface.paste(scaled, (0, 0))
+
+    overlay_height = height - hero_height
+    base_y = hero_height
+    surface.rectangle((0, base_y, width, height), fill=theme.background)
+    padding = int(width * GUTTER_RATIO)
+    if separators:
+        surface.line(((padding, base_y), (width - padding, base_y)), fill=theme.separator, width=2)
+
+    title_font = surface.fonts.get(size=_scaled_font(surface, 0.1))
+    subtitle_font = surface.fonts.get(size=_scaled_font(surface, 0.055))
+    body_font = surface.fonts.get(size=_scaled_font(surface, 0.048))
+
+    cursor_y = base_y + int(overlay_height * 0.2)
+    if meta.title:
+        surface.text((padding, cursor_y), meta.title, font=title_font, fill=theme.foreground)
+        _, title_h = surface.text_size(meta.title, font=title_font)
+        cursor_y += title_h + TEXT_LINE_SPACING
+    if meta.subtitle:
+        surface.text((padding, cursor_y), meta.subtitle, font=subtitle_font, fill=theme.accent)
+        _, sub_h = surface.text_size(meta.subtitle, font=subtitle_font)
+        cursor_y += sub_h + TEXT_LINE_SPACING
+    if meta.details:
+        surface.multiline_text((padding, cursor_y), meta.details, font=body_font, fill=theme.muted, line_spacing=TEXT_LINE_SPACING)
+
+    return surface.image
+
+
+_LAYOUTS: Dict[str, LayoutFunc] = {
+    "single": _render_single,
+    "2col": _render_two_column,
+    "two_column": _render_two_column,
+    "hero": _render_hero,
+}
+
+
+def get_layout(name: str) -> LayoutFunc:
+    return _LAYOUTS.get(name.lower(), _LAYOUTS["single"])
+
+
+def list_layouts() -> Iterable[str]:
+    return _LAYOUTS.keys()
+
+
+__all__ = ["LayoutContent", "LayoutFunc", "get_layout", "list_layouts"]

--- a/server/renderer/pipeline.py
+++ b/server/renderer/pipeline.py
@@ -1,0 +1,285 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, Mapping, Optional, Tuple
+
+from PIL import Image, ImageOps
+
+from ..storage.files import safe_slug
+from ..widgets import WidgetRegistry
+from .layout import LayoutContent, get_layout
+from .surface import FontManager, IconCache, Surface
+from .theme import Theme, get_theme
+
+Color = Tuple[int, int, int]
+Palette = Iterable[Color]
+
+EINK_PALETTES: Dict[str, Tuple[Color, ...]] = {
+    "3": ((255, 255, 255), (0, 0, 0), (255, 0, 0)),
+    "tri": ((255, 255, 255), (0, 0, 0), (255, 0, 0)),
+    "4": ((255, 255, 255), (0, 0, 0), (255, 0, 0), (255, 255, 0)),
+    "7": (
+        (255, 255, 255),
+        (0, 0, 0),
+        (255, 0, 0),
+        (255, 255, 0),
+        (0, 128, 0),
+        (0, 0, 200),
+        (240, 128, 48),
+    ),
+    "8": (
+        (255, 255, 255),
+        (0, 0, 0),
+        (255, 0, 0),
+        (255, 255, 0),
+        (0, 150, 0),
+        (0, 0, 200),
+        (240, 128, 48),
+        (120, 0, 140),
+    ),
+}
+
+ALIAS_PALETTES = {
+    "inky3": "3",
+    "inky4": "4",
+    "inky7": "7",
+    "inky8": "8",
+}
+
+FLOYD_STEINBERG = ((1, 0, 7 / 16), (-1, 1, 3 / 16), (0, 1, 5 / 16), (1, 1, 1 / 16))
+ATKINSON = ((1, 0, 1 / 8), (2, 0, 1 / 8), (-1, 1, 1 / 8), (0, 1, 1 / 8), (1, 1, 1 / 8), (0, 2, 1 / 8))
+
+
+@dataclass
+class PipelineRequest:
+    source: str
+    identifier: str
+    config: Mapping[str, Any] | None
+    layout: str
+    theme: str
+    palette: str
+    dither: str
+    separators: bool = True
+
+
+@dataclass
+class PipelineResult:
+    image: Image.Image
+    output_path: Path
+    cache_path: Path
+    identifier: str
+    source: str
+    theme: Theme
+    layout: str
+    content: LayoutContent
+    from_cache: bool
+
+
+class RendererPipeline:
+    def __init__(self, image_dir: Path, static_dir: Path, target_size: Tuple[int, int]) -> None:
+        self.image_dir = image_dir
+        self.cache_dir = image_dir / "cache"
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        self.static_dir = static_dir
+        self.target_size = target_size
+        self.font_manager = FontManager(self._font_search_paths())
+        self.icon_cache = IconCache(self._icon_search_paths())
+        self._cache: Dict[str, Path] = {}
+        self._last_output: Optional[Path] = None
+
+    def _font_search_paths(self) -> Iterable[Path]:
+        paths = []
+        candidate = self.static_dir / "fonts"
+        if candidate.exists():
+            paths.append(candidate)
+        for extra in (Path("/usr/share/fonts"), Path("/usr/local/share/fonts")):
+            if extra.exists():
+                paths.append(extra)
+        return paths
+
+    def _icon_search_paths(self) -> Iterable[Path]:
+        candidate = self.static_dir / "icons"
+        return [candidate] if candidate.exists() else []
+
+    def render(self, request: PipelineRequest, registry: WidgetRegistry) -> PipelineResult:
+        base_image, content, version_token = self._fetch_source(request, registry)
+        cache_key = self._cache_key(request, version_token)
+        cache_path = self.cache_dir / f"{cache_key}.png"
+
+        theme = get_theme(request.theme)
+        from_cache = False
+        if cache_path.exists():
+            with Image.open(cache_path) as cached:
+                final_image = cached.convert("RGB")
+            from_cache = True
+        else:
+            surface = Surface.create(self.target_size, theme.background, fonts=self.font_manager, icons=self.icon_cache)
+            layout_fn = get_layout(request.layout)
+            composed = layout_fn(surface, base_image, theme, content, request.separators)
+            final_image = apply_palette(composed, request.palette, request.dither)
+            final_image.save(cache_path, format="PNG", optimize=True)
+        final_image = final_image.copy()
+
+        output_path = self._store_output(final_image, request, theme)
+        self._cache[cache_key] = cache_path
+        self._last_output = output_path
+        return PipelineResult(
+            image=final_image,
+            output_path=output_path,
+            cache_path=cache_path,
+            identifier=request.identifier,
+            source=request.source,
+            theme=theme,
+            layout=request.layout,
+            content=content,
+            from_cache=from_cache,
+        )
+
+    def latest_output(self) -> Optional[Path]:
+        if self._last_output and self._last_output.exists():
+            return self._last_output
+        candidates = sorted(self.image_dir.glob("*.png"))
+        return candidates[-1] if candidates else None
+
+    def _store_output(self, image: Image.Image, request: PipelineRequest, theme: Theme) -> Path:
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        slug = safe_slug(request.identifier or "render")
+        base_name = f"{timestamp}_{slug}_{request.layout}_{theme.name}"
+        candidate = self.image_dir / f"{base_name}.png"
+        counter = 1
+        while candidate.exists():
+            candidate = self.image_dir / f"{base_name}_{counter}.png"
+            counter += 1
+        image.save(candidate, format="PNG", optimize=True)
+        return candidate
+
+    def _fetch_source(self, request: PipelineRequest, registry: WidgetRegistry):
+        if request.source == "image":
+            path = self._resolve_image(request.identifier)
+            with Image.open(path) as handle:
+                base = ImageOps.exif_transpose(handle).convert("RGB")
+            stats = path.stat()
+            created = datetime.fromtimestamp(stats.st_mtime).strftime("%d-%m-%Y %H:%M")
+            title = Path(request.identifier).stem.replace("_", " ") or "Afbeelding"
+            content = LayoutContent(
+                title=title,
+                subtitle="Fotogalerij",
+                details=[f"Bestand: {path.name}", f"Laatst bijgewerkt: {created}"],
+                footer="Inky Photoframe",
+            )
+            version = f"{stats.st_mtime_ns}:{stats.st_size}"
+            return base, content, version
+        widget = registry.get(request.identifier)
+        rendered = widget.render(request.config or {}, self.target_size)
+        details = [f"{key}: {value}" for key, value in sorted((request.config or {}).items())] or ["Geen configuratie"]
+        content = LayoutContent(
+            title=widget.name,
+            subtitle=widget.description,
+            details=details,
+            footer="Widget",
+        )
+        version = self._hash_config(request.config or {})
+        return rendered, content, version
+
+    def _resolve_image(self, name: str) -> Path:
+        safe_name = os.path.basename(name)
+        path = self.image_dir / safe_name
+        if not path.exists() or not path.is_file():
+            raise FileNotFoundError(f"Afbeelding niet gevonden: {name}")
+        return path
+
+    def _hash_config(self, config: Mapping[str, Any]) -> str:
+        payload = json.dumps(config, sort_keys=True, ensure_ascii=False).encode("utf-8")
+        return hashlib.sha1(payload).hexdigest()
+
+    def _cache_key(self, request: PipelineRequest, version_token: str) -> str:
+        payload = "|".join(
+            [
+                request.source,
+                request.identifier,
+                version_token,
+                request.layout,
+                request.theme,
+                request.palette,
+                request.dither,
+                "1" if request.separators else "0",
+            ]
+        )
+        return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _resolve_palette(name: str) -> Tuple[Color, ...]:
+    key = ALIAS_PALETTES.get(name.lower(), name.lower())
+    return EINK_PALETTES.get(key, EINK_PALETTES["7"])
+
+
+def _nearest_color(color: Tuple[float, float, float], palette: Palette) -> Tuple[int, int, int]:
+    r, g, b = color
+    best: Optional[Tuple[int, int, int]] = None
+    best_dist = float("inf")
+    for pr, pg, pb in palette:
+        dist = (r - pr) ** 2 + (g - pg) ** 2 + (b - pb) ** 2
+        if dist < best_dist:
+            best_dist = dist
+            best = (pr, pg, pb)
+    if best is None:
+        best = (0, 0, 0)
+    return best
+
+
+def _clamp(value: float) -> float:
+    return min(255.0, max(0.0, value))
+
+
+def _map_palette(image: Image.Image, palette: Palette) -> Image.Image:
+    src = image.convert("RGB")
+    width, height = src.size
+    out = Image.new("RGB", (width, height))
+    src_pixels = src.load()
+    out_pixels = out.load()
+    for y in range(height):
+        for x in range(width):
+            out_pixels[x, y] = _nearest_color(src_pixels[x, y], palette)
+    return out
+
+
+def _error_diffuse(image: Image.Image, palette: Palette, matrix) -> Image.Image:
+    width, height = image.size
+    working = image.convert("RGB")
+    buffer = [[[float(channel) for channel in working.getpixel((x, y))] for x in range(width)] for y in range(height)]
+    out = Image.new("RGB", (width, height))
+    out_pixels = out.load()
+    for y in range(height):
+        for x in range(width):
+            old = [
+                _clamp(buffer[y][x][0]),
+                _clamp(buffer[y][x][1]),
+                _clamp(buffer[y][x][2]),
+            ]
+            new_color = _nearest_color(tuple(old), palette)
+            out_pixels[x, y] = new_color
+            error = [old[0] - new_color[0], old[1] - new_color[1], old[2] - new_color[2]]
+            for dx, dy, ratio in matrix:
+                nx, ny = x + dx, y + dy
+                if 0 <= nx < width and 0 <= ny < height:
+                    for channel in range(3):
+                        buffer[ny][nx][channel] += error[channel] * ratio
+    return out
+
+
+def apply_palette(image: Image.Image, palette_name: str, dither: str) -> Image.Image:
+    palette = _resolve_palette(palette_name)
+    mode = dither.lower()
+    if mode in ("none", "off", "false"):
+        return _map_palette(image, palette)
+    if mode.startswith("atk"):
+        return _error_diffuse(image, palette, ATKINSON)
+    return _error_diffuse(image, palette, FLOYD_STEINBERG)
+
+
+__all__ = ["RendererPipeline", "PipelineRequest", "PipelineResult", "apply_palette"]

--- a/server/renderer/surface.py
+++ b/server/renderer/surface.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Iterable, Optional, Sequence, Tuple
+
+from PIL import Image, ImageDraw, ImageFont
+
+DEFAULT_FONT_NAMES: Sequence[str] = (
+    "DejaVuSans.ttf",
+    "DejaVuSansDisplay.ttf",
+    "Arial.ttf",
+    "LiberationSans-Regular.ttf",
+)
+
+
+@lru_cache(maxsize=128)
+def _load_font(path: str, size: int) -> ImageFont.ImageFont:
+    try:
+        return ImageFont.truetype(path, size=size)
+    except OSError:
+        return ImageFont.load_default()
+
+
+class FontManager:
+    """Utility for loading fonts with caching and fallbacks."""
+
+    def __init__(self, search_paths: Iterable[Path] | None = None, fallback: str | None = None) -> None:
+        self._search_paths = [Path(p) for p in (search_paths or [])]
+        self._fallback = fallback or DEFAULT_FONT_NAMES[0]
+
+    def _resolve(self, name: str | None) -> str:
+        candidates: list[str] = []
+        if name:
+            candidates.append(name)
+        candidates.extend(DEFAULT_FONT_NAMES)
+        candidates.append(self._fallback)
+
+        for candidate in candidates:
+            if os.path.isabs(candidate) and Path(candidate).exists():
+                return candidate
+            for base in self._search_paths:
+                path = base / candidate
+                if path.exists():
+                    return str(path)
+        return candidates[0]
+
+    def get(self, size: int, name: str | None = None) -> ImageFont.ImageFont:
+        path = self._resolve(name)
+        return _load_font(path, size)
+
+
+class IconCache:
+    """Lazy cache for bitmap icons."""
+
+    def __init__(self, search_paths: Iterable[Path] | None = None) -> None:
+        self._search_paths = [Path(p) for p in (search_paths or [])]
+        self._cache: dict[tuple[str, Optional[int]], Image.Image] = {}
+
+    def _resolve(self, name: str) -> Path:
+        possible = [name]
+        if "." not in name:
+            possible.extend([f"{name}.png", f"{name}.jpg", f"{name}.jpeg"])
+        for candidate in possible:
+            for base in self._search_paths:
+                path = base / candidate
+                if path.exists():
+                    return path
+        raise FileNotFoundError(f"Icon not found: {name}")
+
+    def get(self, name: str, size: Optional[int] = None) -> Image.Image:
+        key = (name, size)
+        if key in self._cache:
+            return self._cache[key].copy()
+
+        path = self._resolve(name)
+        with Image.open(path) as handle:
+            icon = handle.convert("RGBA")
+        if size:
+            icon = icon.resize((size, size), Image.Resampling.LANCZOS)
+        self._cache[key] = icon
+        return icon.copy()
+
+
+@dataclass
+class Surface:
+    image: Image.Image
+    draw: ImageDraw.ImageDraw
+    fonts: FontManager
+    icons: IconCache
+
+    @classmethod
+    def create(
+        cls,
+        size: Tuple[int, int],
+        background: Tuple[int, int, int],
+        *,
+        fonts: FontManager,
+        icons: IconCache,
+    ) -> "Surface":
+        img = Image.new("RGB", size, color=background)
+        draw = ImageDraw.Draw(img)
+        return cls(image=img, draw=draw, fonts=fonts, icons=icons)
+
+    def text(
+        self,
+        position: Tuple[int, int],
+        text: str,
+        *,
+        font: Optional[ImageFont.ImageFont] = None,
+        fill: Tuple[int, int, int] | str = "black",
+        anchor: Optional[str] = None,
+    ) -> None:
+        font = font or self.fonts.get(size=16)
+        self.draw.text(position, text, fill=fill, font=font, anchor=anchor)
+
+    def multiline_text(
+        self,
+        position: Tuple[int, int],
+        lines: Iterable[str],
+        *,
+        font: Optional[ImageFont.ImageFont] = None,
+        fill: Tuple[int, int, int] | str = "black",
+        line_spacing: int = 4,
+    ) -> int:
+        font = font or self.fonts.get(size=16)
+        x, y = position
+        height = 0
+        for line in lines:
+            self.draw.text((x, y + height), line, fill=fill, font=font)
+            _, line_h = self.text_size(line, font=font)
+            height += line_h + line_spacing
+        return height
+
+    def rectangle(
+        self,
+        box: Tuple[int, int, int, int],
+        *,
+        fill: Tuple[int, int, int] | str,
+        outline: Tuple[int, int, int] | str | None = None,
+        width: int = 1,
+    ) -> None:
+        self.draw.rectangle(box, fill=fill, outline=outline, width=width)
+
+    def line(
+        self,
+        points: Sequence[Tuple[int, int]],
+        *,
+        fill: Tuple[int, int, int] | str,
+        width: int = 1,
+    ) -> None:
+        self.draw.line(points, fill=fill, width=width)
+
+    def paste(self, img: Image.Image, box: Tuple[int, int], *, mask: Optional[Image.Image] = None) -> None:
+        self.image.paste(img, box, mask=mask)
+
+    def text_size(self, text: str, *, font: Optional[ImageFont.ImageFont] = None) -> Tuple[int, int]:
+        font = font or self.fonts.get(size=16)
+        return self.draw.textsize(text, font=font)
+
+
+__all__ = ["FontManager", "IconCache", "Surface", "DEFAULT_FONT_NAMES"]

--- a/server/renderer/theme.py
+++ b/server/renderer/theme.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, Tuple
+
+Color = Tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class Theme:
+    """Represents a named colour theme with semantic roles."""
+
+    name: str
+    background: Color
+    foreground: Color
+    accent: Color
+    muted: Color
+    separator: Color
+
+
+_THEMES: Dict[str, Theme] = {
+    "light": Theme(
+        name="light",
+        background=(245, 245, 245),
+        foreground=(34, 34, 34),
+        accent=(220, 60, 60),
+        muted=(120, 120, 120),
+        separator=(200, 200, 200),
+    ),
+    "dark": Theme(
+        name="dark",
+        background=(20, 20, 20),
+        foreground=(235, 235, 235),
+        accent=(255, 120, 80),
+        muted=(140, 140, 140),
+        separator=(70, 70, 70),
+    ),
+    "warm": Theme(
+        name="warm",
+        background=(250, 244, 232),
+        foreground=(60, 40, 20),
+        accent=(208, 94, 54),
+        muted=(160, 132, 96),
+        separator=(214, 198, 176),
+    ),
+    "cool": Theme(
+        name="cool",
+        background=(235, 242, 248),
+        foreground=(24, 48, 72),
+        accent=(64, 132, 214),
+        muted=(104, 140, 168),
+        separator=(180, 204, 220),
+    ),
+}
+
+
+def get_theme(name: str) -> Theme:
+    return _THEMES.get(name.lower(), _THEMES["light"])
+
+
+def list_themes() -> Iterable[str]:
+    return _THEMES.keys()
+
+
+__all__ = ["Theme", "get_theme", "list_themes"]


### PR DESCRIPTION
## Summary
- add a renderer package with drawing helpers, theme presets, and layout presets
- implement a rendering pipeline with palette-aware dithering and PNG output caching
- update the render and preview endpoints to run through the new pipeline and expose layout/theme options

## Testing
- python -m compileall server

------
https://chatgpt.com/codex/tasks/task_e_68d0f9721c38832c99fd072563919d86