### PR TITLE
Introduce driver abstraction for Inky frames

### DIFF
--- a/server/api/render.py
+++ b/server/api/render.py
@@ -82,7 +82,7 @@ async def render_now(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     if not payload.dry_run:
-        inky_display.display_image(image)
+        inky_display.push_frame(image)
         state.last_rendered = identifier
 
     return RenderNowResponse(ok=True, source=source, identifier=identifier, dry_run=payload.dry_run)

--- a/server/device/__init__.py
+++ b/server/device/__init__.py
@@ -1,0 +1,5 @@
+"""Hardware driver interfaces for pushing frames to display devices."""
+
+from .driver import FrameDriver, InkyDriver
+
+__all__ = ["FrameDriver", "InkyDriver"]

--- a/server/device/driver.py
+++ b/server/device/driver.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import sys
+import threading
+from pathlib import Path
+from typing import Iterable, Optional, Protocol, runtime_checkable
+
+try:
+    from PIL import Image
+except Exception as exc:  # pragma: no cover - defensive import guard
+    print("ERROR: Pillow (PIL) is required:", exc, file=sys.stderr)
+    raise SystemExit(1) from exc
+
+
+@runtime_checkable
+class FrameDriver(Protocol):
+    """Protocol describing the interface for pushing frames to a device."""
+
+    def push_frame(self, image_path: Path) -> None:
+        """Push the PNG frame stored at *image_path* to the device."""
+
+
+def _normalise_palette(raw_palette: Iterable[int]) -> set[tuple[int, int, int]]:
+    values = list(raw_palette)
+    colours: set[tuple[int, int, int]] = set()
+    for index in range(0, len(values), 3):
+        triplet = values[index : index + 3]
+        if len(triplet) < 3:
+            break
+        colours.add((int(triplet[0]), int(triplet[1]), int(triplet[2])))
+    return colours
+
+
+class InkyDriver:
+    """Driver implementation for an attached Inky display."""
+
+    def __init__(self, inky_display: object) -> None:
+        self._inky_display = inky_display
+        self._lock = threading.Lock()
+        palette = getattr(inky_display, "palette", None)
+        self._allowed_palette: Optional[set[tuple[int, int, int]]] = None
+        if palette is not None:
+            try:
+                self._allowed_palette = _normalise_palette(palette)
+            except Exception:
+                self._allowed_palette = None
+
+    def push_frame(self, image_path: Path) -> None:
+        if not image_path.exists() or not image_path.is_file():
+            raise FileNotFoundError(f"Frame not found: {image_path}")
+
+        with Image.open(image_path) as image:
+            image.load()
+            if image.format != "PNG":
+                raise ValueError("Frame driver requires PNG input")
+            if image.mode != "P":
+                raise ValueError("Expected palettized PNG frame for Inky display")
+            palette = image.getpalette()
+            if palette is None:
+                raise ValueError("PNG frame does not contain a palette")
+
+            allowed = self._allowed_palette
+            if allowed:
+                used_entries = {index for _, index in (image.getcolors() or [])}
+                for entry in used_entries:
+                    offset = entry * 3
+                    colour = tuple(palette[offset : offset + 3])
+                    if colour not in allowed:
+                        raise ValueError(f"Unsupported colour for Inky display: {colour}")
+
+            rgb_image = image.convert("RGB")
+
+        with self._lock:
+            self._inky_display.set_image(rgb_image)
+            self._inky_display.show()
+
+
+__all__ = ["FrameDriver", "InkyDriver"]

--- a/server/inky/display.py
+++ b/server/inky/display.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import os
 import sys
-import threading
-from typing import Tuple
+import tempfile
+from pathlib import Path
+from typing import Optional, Tuple
 
 try:
     from PIL import Image
@@ -16,28 +18,90 @@ except Exception as exc:  # pragma: no cover - defensive import guard
     print("ERROR: inky library is required and the display must be connected:", exc, file=sys.stderr)
     raise SystemExit(1) from exc
 
+from ..device.driver import FrameDriver, InkyDriver
+
 try:
-    inky_display = auto()
+    _inky_display = auto()
 except Exception as exc:  # pragma: no cover - defensive import guard
     print("ERROR: Could not initialize Inky display:", exc, file=sys.stderr)
     raise SystemExit(1) from exc
 
-INKY_LOCK = threading.Lock()
-ROTATE_180_ON_DISPLAY = False
+_ROTATE_180_ON_DISPLAY = False
+_DRIVER: Optional[FrameDriver] = None
+_HARDWARE_READY = False
 
 try:
-    DISP_W, DISP_H = inky_display.width, inky_display.height
+    DISP_W, DISP_H = _inky_display.width, _inky_display.height
     if DISP_W < DISP_H:
         DISP_W, DISP_H = DISP_H, DISP_W
+    _HARDWARE_READY = True
     DISPLAY_READY = True
+    _DRIVER = InkyDriver(_inky_display)
 except Exception as exc:  # pragma: no cover - hardware specific
     print("ERROR: Could not determine Inky display dimensions:", exc, file=sys.stderr)
+    _HARDWARE_READY = False
     DISPLAY_READY = False
     DISP_W, DISP_H = 800, 480
+    _DRIVER = None
+
+_FRAME_DIR = Path(os.environ.get("PHOTOFRAME_FRAME_DIR", tempfile.gettempdir())) / "photoframe"
+_FRAME_BASENAME = "last-frame.png"
+_FRAME_DIR.mkdir(parents=True, exist_ok=True)
+_LAST_FRAME_PATH: Optional[Path] = None
+
+_DEFAULT_PALETTE = [
+    255, 255, 255,
+    0, 0, 0,
+    255, 0, 0,
+    255, 255, 0,
+]
+
+
+def _palette_image() -> Image.Image:
+    palette_data = getattr(_inky_display, "palette", None)
+    if palette_data is not None:
+        palette = list(palette_data)[: 256 * 3]
+    else:
+        palette = []
+    if not palette or not any(palette):
+        palette = list(_DEFAULT_PALETTE)
+    if len(palette) < 256 * 3:
+        palette.extend([0] * (256 * 3 - len(palette)))
+    palette_image = Image.new("P", (1, 1))
+    palette_image.putpalette(palette[: 256 * 3])
+    return palette_image
+
+
+def _default_frame_path() -> Path:
+    return _FRAME_DIR / _FRAME_BASENAME
+
+
+def _ensure_driver() -> FrameDriver:
+    global _DRIVER
+    if _DRIVER is None:
+        if not _HARDWARE_READY:
+            raise RuntimeError("Inky display not available")
+        _DRIVER = InkyDriver(_inky_display)
+    return _DRIVER
+
+
+def _prepare_frame(image: Image.Image) -> Image.Image:
+    need_w, need_h = _inky_display.width, _inky_display.height
+    rgb = image.convert("RGB")
+    if rgb.size != (need_w, need_h):
+        rgb = rgb.resize((need_w, need_h), Image.Resampling.LANCZOS)
+    if _ROTATE_180_ON_DISPLAY:
+        rgb = rgb.transpose(Image.Transpose.ROTATE_180)
+    palette_image = _palette_image()
+    try:
+        palettized = rgb.quantize(palette=palette_image, dither=Image.Dither.NONE)
+    except AttributeError:  # pragma: no cover - Pillow < 10 compatibility
+        palettized = rgb.quantize(palette=palette_image, dither=Image.NONE)
+    return palettized
 
 
 def is_ready() -> bool:
-    return DISPLAY_READY
+    return DISPLAY_READY and _DRIVER is not None
 
 
 def target_size() -> Tuple[int, int]:
@@ -45,26 +109,51 @@ def target_size() -> Tuple[int, int]:
 
 
 def panel_size() -> Tuple[int, int]:
-    return inky_display.width, inky_display.height
+    return _inky_display.width, _inky_display.height
 
 
 def set_rotation(enabled: bool) -> None:
-    global ROTATE_180_ON_DISPLAY
-    ROTATE_180_ON_DISPLAY = enabled
+    global _ROTATE_180_ON_DISPLAY
+    _ROTATE_180_ON_DISPLAY = enabled
 
 
-def display_image(img: Image.Image) -> None:
+def set_driver(driver: Optional[FrameDriver], *, ready: Optional[bool] = None) -> None:
+    global _DRIVER, DISPLAY_READY
+    _DRIVER = driver
+    if ready is not None:
+        DISPLAY_READY = ready
+    else:
+        DISPLAY_READY = _HARDWARE_READY if driver is None else True
+
+
+def last_frame_path() -> Optional[Path]:
+    return _LAST_FRAME_PATH
+
+
+def push_frame(image: Image.Image, *, frame_path: Optional[Path] = None) -> Path:
     if not DISPLAY_READY:
         raise RuntimeError("Inky display not available")
 
-    need_w, need_h = inky_display.width, inky_display.height
-    rgb = img.convert("RGB")
-    if rgb.size != (need_w, need_h):
-        rgb = rgb.resize((need_w, need_h), Image.Resampling.LANCZOS)
+    driver = _ensure_driver()
+    palettized = _prepare_frame(image)
 
-    if ROTATE_180_ON_DISPLAY:
-        rgb = rgb.transpose(Image.Transpose.ROTATE_180)
+    output_path = frame_path or _default_frame_path()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    palettized.save(output_path, format="PNG")
 
-    with INKY_LOCK:
-        inky_display.set_image(rgb)
-        inky_display.show()
+    driver.push_frame(output_path)
+
+    global _LAST_FRAME_PATH
+    _LAST_FRAME_PATH = output_path
+    return output_path
+
+
+__all__ = [
+    "is_ready",
+    "target_size",
+    "panel_size",
+    "set_rotation",
+    "set_driver",
+    "last_frame_path",
+    "push_frame",
+]

--- a/server/routes/images.py
+++ b/server/routes/images.py
@@ -177,7 +177,7 @@ def _carousel_worker() -> None:
             with open(path, "rb") as fh:
                 img = Image.open(fh)
                 img = ImageOps.exif_transpose(img).convert("RGB")
-            inky_display.display_image(img)
+            inky_display.push_frame(img)
         except Exception as exc:
             print(f"Display error for {path.name}: {exc}", file=sys.stderr)
         minutes = max(1, int(CAROUSEL_MINUTES))
@@ -291,7 +291,7 @@ def display_endpoint(request: Request, params: Dict[str, str]) -> JsonResponse:
         with open(path, "rb") as fh:
             img = Image.open(fh)
             img = ImageOps.exif_transpose(img).convert("RGB")
-        inky_display.display_image(img)
+        inky_display.push_frame(img)
         with STATE_LOCK:
             files = list_images_sorted(request.context.image_dir)
             global CURRENT_INDEX


### PR DESCRIPTION
## Summary
- add a generic frame driver protocol and an Inky implementation that validates palettized PNG frames before pushing to the device
- refactor the display adapter to save processed frames as palettized PNGs, expose the last frame path, and coordinate driver lifecycle
- switch render and image routes to the new push_frame workflow so tests can inspect written frame files

## Testing
- python -m compileall photoframe

------
https://chatgpt.com/codex/tasks/task_e_68d0f977240c832c9c4caf2db7ee0645