### PR TITLE
Add deployment install automation and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,114 @@
 # Inky Photoframe Dashboard
 
-Een lichtgewicht dashboard voor het beheren van de Inky Photoframe fotocarrousel op een Raspberry Pi. De webinterface is geoptimaliseerd voor e-ink schermen (hoog contrast, beperkte kleuren) en draait zonder externe frameworks zodat alles responsief blijft op een Pi Zero.
+Een lichtgewicht dashboard voor het beheren van de Inky Photoframe fotocarrousel op een Raspberry Pi. De webinterface is geoptimaliseerd voor e-ink schermen (hoog contrast, beperkte kleuren) en draait zonder externe front-end frameworks zodat alles responsief blijft op een Pi Zero.
 
-## Starten
+## Starten (handmatig)
 
 ```bash
 ./photo.py
 ```
 
 De server start standaard op poort `8080` en serveert de interface via `http://<pi-adres>:8080/`. Afbeeldingen worden opgeslagen onder `/image` (pas dit aan in `photo.py` als je een andere map wilt gebruiken). De eerste start maakt de map automatisch aan.
+
+## Installatie via `install.sh`
+
+Het script automatiseert de volledige installatie op Debian/Raspberry Pi OS (Bookworm of nieuwer) met systemd.
+
+### Voorbereiding
+
+1. Zorg dat de broncode beschikbaar is op het systeem, bijvoorbeeld via `git clone`.
+2. Voer het script uit vanuit de hoofdmap van de repository:
+   ```bash
+   sudo ./install.sh
+   ```
+
+Het script kan met omgevingsvariabelen worden gestuurd:
+
+- `SKIP_APT=1` – sla het installeren van OS-pakketten over (handig in CI wanneer afhankelijkheden al aanwezig zijn).
+- `SKIP_SYSTEMD=1` – kopieer geen systemd-bestand en voer geen `systemctl daemon-reload` uit.
+- `SKIP_UDEV=1` – installeer geen udev-regel.
+
+### Wat het script doet
+
+- Installeert Python 3.11, build-tooling en lichte fonts (`fonts-dejavu-*`) via `apt`.
+- Creëert een systeemgebruiker `photoframe` (lid van `spi`, `i2c`, `render`, `video` indien aanwezig).
+- Maakt directories aan onder `/opt/photoframe`, `/var/lib/photoframe`, `/var/cache/photoframe`, `/var/log/photoframe` en `/etc/photoframe`.
+- Kopieert de applicatie naar `/opt/photoframe/app` en maakt een Python 3.11-venv in `/opt/photoframe/venv` met alle Python dependencies (FastAPI, Uvicorn, Pillow, Inky, enz.).
+- Installeert een helper-script (`/opt/photoframe/bin/photoframe-server`) dat de server met de juiste parameters start.
+- Plaatst `systemd/photoframe.service` in `/etc/systemd/system/photoframe.service` en een udev-regel in `/etc/udev/rules.d/99-photoframe.rules`.
+- Maakt `/etc/logrotate.d/photoframe` aan voor logrotatie en genereert standaardconfiguratie in `/etc/photoframe/photoframe.env`.
+
+Na afloop:
+
+```bash
+sudo systemctl enable --now photoframe.service
+sudo systemctl status photoframe.service
+```
+
+De standaard logs staan in `/var/log/photoframe/photoframe.log`.
+
+### Environment (.env)
+
+Het bestand `/etc/photoframe/photoframe.env` wordt éénmalig aangemaakt. Verander de waarden en herstart de service om wijzigingen toe te passen.
+
+| Variabele           | Default                               | Omschrijving |
+|---------------------|---------------------------------------|--------------|
+| `PHOTOF_HOST`       | `0.0.0.0`                             | Bindadres voor Uvicorn |
+| `PHOTOF_PORT`       | `8080`                                | Poort waarop de server luistert |
+| `PHOTOF_IMAGE_DIR`  | `/var/lib/photoframe/images`          | Map voor verwerkte afbeeldingen |
+| `PHOTOF_ADMIN_TOKEN`| _(leeg)_                              | Token voor admin-API (laat leeg om uit te schakelen) |
+| `PHOTOF_RATE_LIMIT` | `30`                                  | Limiet voor admin-verzoeken per minuut |
+| `PHOTOF_LOG_FILE`   | `/var/log/photoframe/photoframe.log`  | Pad naar het logbestand |
+| `PHOTOF_LOG_LEVEL`  | `info`                                | Uvicorn logniveau |
+| `PHOTOF_EXTRA_ARGS` | _(leeg)_                              | Extra CLI-argumenten die aan `server` worden doorgegeven |
+
+### Logrotatie
+
+`/etc/logrotate.d/photoframe` roteert het logbestand dagelijks, bewaart zeven rotaties en comprimeert oude logs. Het bestand wordt opnieuw aangemaakt bij een herinstallatie en gebruikt `copytruncate`, zodat de service tijdens het roteren kan blijven draaien.
+
+### Systemd-service en udev
+
+- De systemd-unit heet `photoframe.service` en gebruikt het helper-script onder `/opt/photoframe/bin/photoframe-server`.
+- De udev-regel geeft de gebruiker `photoframe` toegang tot `spidev`, `i2c` en framebuffer-devices, zodat het Inky-display zonder rootrechten kan worden aangestuurd. Vergeet niet `sudo udevadm trigger` uit te voeren of het systeem te herstarten na installatie.
+
+### Testen op een schone omgeving
+
+Gebruik onderstaande handmatige check (ook bruikbaar in CI) om het script in een verse Debian Bookworm-container te testen:
+
+```bash
+docker run --rm -it debian:bookworm bash -lc "\
+  apt-get update && \
+  apt-get install -y git sudo python3.11 python3.11-venv && \
+  useradd -m tester && \
+  su - tester -c 'git clone <repo-url> photoframe && cd photoframe && sudo SKIP_SYSTEMD=1 SKIP_UDEV=1 ./install.sh'"
+```
+
+De flags `SKIP_SYSTEMD` en `SKIP_UDEV` voorkomen foutmeldingen in minimalistische containers zonder systemd/udev. Controleer na afloop dat `/opt/photoframe` en de virtuele omgeving aanwezig zijn en dat `photoframe-server` de applicatie kan starten.
+
+### Rollback / verwijderen
+
+1. Stop en deactiveer de service:
+   ```bash
+   sudo systemctl stop photoframe.service
+   sudo systemctl disable photoframe.service
+   sudo systemctl daemon-reload
+   ```
+2. Verwijder configuratiebestanden:
+   ```bash
+   sudo rm -f /etc/systemd/system/photoframe.service
+   sudo rm -f /etc/udev/rules.d/99-photoframe.rules
+   sudo rm -f /etc/logrotate.d/photoframe
+   sudo rm -rf /etc/photoframe
+   ```
+   Voer indien nodig `sudo udevadm control --reload-rules` uit.
+3. Verwijder applicatie- en data-directories:
+   ```bash
+   sudo rm -rf /opt/photoframe /var/lib/photoframe /var/cache/photoframe /var/log/photoframe
+   ```
+4. (Optioneel) verwijder de gebruiker:
+   ```bash
+   sudo userdel photoframe
+   ```
 
 ## Front-end structuur
 

--- a/bin/photoframe-server
+++ b/bin/photoframe-server
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE=${ENV_FILE:-/etc/photoframe/photoframe.env}
+APP_HOME=${APP_HOME:-/opt/photoframe}
+APP_SOURCE_DIR=${APP_SOURCE_DIR:-$APP_HOME/app}
+VENV_DIR=${VENV_DIR:-$APP_HOME/venv}
+
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck source=/dev/null
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+PHOTOF_HOST=${PHOTOF_HOST:-0.0.0.0}
+PHOTOF_PORT=${PHOTOF_PORT:-8080}
+PHOTOF_IMAGE_DIR=${PHOTOF_IMAGE_DIR:-/var/lib/photoframe/images}
+PHOTOF_ADMIN_TOKEN=${PHOTOF_ADMIN_TOKEN:-}
+PHOTOF_RATE_LIMIT=${PHOTOF_RATE_LIMIT:-30}
+PHOTOF_LOG_FILE=${PHOTOF_LOG_FILE:-/var/log/photoframe/photoframe.log}
+PHOTOF_LOG_LEVEL=${PHOTOF_LOG_LEVEL:-info}
+PHOTOF_EXTRA_ARGS=${PHOTOF_EXTRA_ARGS:-}
+
+cd "$APP_SOURCE_DIR"
+
+if [[ ! -x "$VENV_DIR/bin/python" ]]; then
+  echo "Kan $VENV_DIR/bin/python niet vinden" >&2
+  exit 1
+fi
+
+mkdir -p "$PHOTOF_IMAGE_DIR" 2>/dev/null || true
+touch "$PHOTOF_LOG_FILE" 2>/dev/null || true
+
+CMD=("$VENV_DIR/bin/python" -m server \
+  --host "$PHOTOF_HOST" \
+  --port "$PHOTOF_PORT" \
+  --image-dir "$PHOTOF_IMAGE_DIR" \
+  --rate-limit "$PHOTOF_RATE_LIMIT" \
+  --log-file "$PHOTOF_LOG_FILE" \
+  --log-level "$PHOTOF_LOG_LEVEL")
+
+if [[ -n "$PHOTOF_ADMIN_TOKEN" ]]; then
+  CMD+=("--admin-token=$PHOTOF_ADMIN_TOKEN")
+fi
+
+if [[ -n "$PHOTOF_EXTRA_ARGS" ]]; then
+  # shellcheck disable=SC2206
+  EXTRA=($PHOTOF_EXTRA_ARGS)
+  CMD+=("${EXTRA[@]}")
+fi
+
+exec "${CMD[@]}"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+APP_USER=${APP_USER:-photoframe}
+APP_GROUP=${APP_GROUP:-$APP_USER}
+APP_HOME=${APP_HOME:-/opt/photoframe}
+APP_SOURCE_DIR=${APP_SOURCE_DIR:-$APP_HOME/app}
+APP_BIN_DIR=${APP_BIN_DIR:-$APP_HOME/bin}
+VENV_DIR=${VENV_DIR:-$APP_HOME/venv}
+DATA_DIR=${DATA_DIR:-/var/lib/photoframe}
+IMAGE_DIR=${IMAGE_DIR:-$DATA_DIR/images}
+CACHE_DIR=${CACHE_DIR:-/var/cache/photoframe}
+LOG_DIR=${LOG_DIR:-/var/log/photoframe}
+ENV_DIR=${ENV_DIR:-/etc/photoframe}
+ENV_FILE=${ENV_FILE:-$ENV_DIR/photoframe.env}
+SERVICE_NAME=${SERVICE_NAME:-photoframe.service}
+SERVICE_DEST=${SERVICE_DEST:-/etc/systemd/system/$SERVICE_NAME}
+UDEV_DEST=${UDEV_DEST:-/etc/udev/rules.d/99-photoframe.rules}
+LOGROTATE_DEST=${LOGROTATE_DEST:-/etc/logrotate.d/photoframe}
+PYTHON_BIN=${PYTHON_BIN:-python3.11}
+
+SKIP_APT=${SKIP_APT:-0}
+SKIP_SYSTEMD=${SKIP_SYSTEMD:-0}
+SKIP_UDEV=${SKIP_UDEV:-0}
+
+APT_PACKAGES=(
+  python3.11
+  python3.11-venv
+  python3.11-dev
+  python3-distutils
+  python3-pip
+  git
+  rsync
+  fonts-dejavu-core
+  fonts-dejavu-extra
+  libjpeg-dev
+  zlib1g-dev
+  libopenjp2-7
+  libtiff5
+)
+
+PIP_PACKAGES=(
+  fastapi==0.110.0
+  uvicorn[standard]==0.27.1
+  pillow==10.2.0
+  inky==2.2.1
+  jinja2==3.1.3
+  numpy==1.26.4
+  pydantic==1.10.14
+  python-dotenv==1.0.1
+  python-multipart==0.0.9
+)
+
+log() { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33m[warn]\033[0m %s\n' "$*"; }
+die() { printf '\033[1;31m[err]\033[0m %s\n' "$*" >&2; exit 1; }
+
+require_root() {
+  if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+    die "Voer dit script uit als root (bijv. via sudo)."
+  fi
+}
+
+ensure_commands() {
+  if ! command -v "$PYTHON_BIN" >/dev/null 2>&1 && [[ "$SKIP_APT" == "1" ]]; then
+    die "Python 3.11 ontbreekt en SKIP_APT=1 voorkomt installatie."
+  fi
+}
+
+install_packages() {
+  if [[ "$SKIP_APT" == "1" ]]; then
+    warn "Sla apt-get installatie over (SKIP_APT=1). Zorg dat vereiste pakketten aanwezig zijn."
+    return
+  fi
+  if ! command -v apt-get >/dev/null 2>&1; then
+    die "apt-get niet gevonden. Dit script verwacht een Debian/Ubuntu-achtige distributie."
+  fi
+  log "Werk apt-cache bij"
+  apt-get update -y
+  log "Installeer OS-afhankelijkheden"
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}"
+}
+
+ensure_group_user() {
+  if ! getent group "$APP_GROUP" >/dev/null 2>&1; then
+    log "Maak groep $APP_GROUP"
+    groupadd --system "$APP_GROUP"
+  fi
+  if ! id -u "$APP_USER" >/dev/null 2>&1; then
+    log "Maak systeemgebruiker $APP_USER"
+    useradd --system --gid "$APP_GROUP" --home "$APP_HOME" --create-home --shell /usr/sbin/nologin "$APP_USER"
+  fi
+  for extra in spi i2c render video; do
+    if getent group "$extra" >/dev/null 2>&1; then
+      usermod -a -G "$extra" "$APP_USER" || true
+    fi
+  done
+}
+
+create_directories() {
+  log "Maak directories"
+  install -d -m 0755 "$APP_HOME"
+  install -d -m 0755 -o "$APP_USER" -g "$APP_GROUP" "$APP_SOURCE_DIR" "$APP_BIN_DIR"
+  install -d -m 0755 -o "$APP_USER" -g "$APP_GROUP" "$DATA_DIR" "$IMAGE_DIR" "$CACHE_DIR"
+  install -d -m 0755 "$ENV_DIR"
+  install -d -m 0755 -o "$APP_USER" -g "$APP_GROUP" "$LOG_DIR"
+  touch "$LOG_DIR/photoframe.log"
+  chown "$APP_USER":"$APP_GROUP" "$LOG_DIR/photoframe.log"
+}
+
+sync_sources() {
+  if [[ "$SCRIPT_DIR" == "$APP_SOURCE_DIR" ]]; then
+    warn "Bron en doeldirectory zijn gelijk; sla kopiëren over."
+    return
+  fi
+  if [[ ! -d "$SCRIPT_DIR" ]]; then
+    die "Kan bronpad $SCRIPT_DIR niet vinden"
+  fi
+  log "Kopieer applicatiebestanden naar $APP_SOURCE_DIR"
+  rsync -a --delete --exclude '.git' --exclude '__pycache__' "$SCRIPT_DIR"/ "$APP_SOURCE_DIR"/
+  chown -R "$APP_USER":"$APP_GROUP" "$APP_SOURCE_DIR"
+}
+
+setup_venv() {
+  log "Maak/werk Python-venv bij in $VENV_DIR"
+  "$PYTHON_BIN" -m venv "$VENV_DIR"
+  "$VENV_DIR/bin/python" -m pip install --upgrade pip wheel setuptools
+  "$VENV_DIR/bin/pip" install --upgrade "${PIP_PACKAGES[@]}"
+  chown -R "$APP_USER":"$APP_GROUP" "$VENV_DIR"
+}
+
+install_helper_scripts() {
+  if [[ ! -f "$SCRIPT_DIR/bin/photoframe-server" ]]; then
+    die "Helper-script bin/photoframe-server ontbreekt"
+  fi
+  log "Installeer helper-script"
+  install -Dm0755 "$SCRIPT_DIR/bin/photoframe-server" "$APP_BIN_DIR/photoframe-server"
+  chown "$APP_USER":"$APP_GROUP" "$APP_BIN_DIR/photoframe-server"
+}
+
+install_systemd_unit() {
+  if [[ "$SKIP_SYSTEMD" == "1" ]]; then
+    warn "Sla systemd-installatie over (SKIP_SYSTEMD=1)."
+    return
+  fi
+  if [[ ! -f "$SCRIPT_DIR/systemd/photoframe.service" ]]; then
+    die "systemd/photoframe.service ontbreekt"
+  fi
+  log "Installeer systemd-unit naar $SERVICE_DEST"
+  install -Dm0644 "$SCRIPT_DIR/systemd/photoframe.service" "$SERVICE_DEST"
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+  else
+    warn "systemctl niet gevonden; sla daemon-reload over."
+  fi
+}
+
+install_udev_rules() {
+  if [[ "$SKIP_UDEV" == "1" ]]; then
+    warn "Sla udev-regels over (SKIP_UDEV=1)."
+    return
+  fi
+  if [[ ! -f "$SCRIPT_DIR/udev/99-photoframe.rules" ]]; then
+    die "udev/99-photoframe.rules ontbreekt"
+  fi
+  log "Installeer udev-regels"
+  install -Dm0644 "$SCRIPT_DIR/udev/99-photoframe.rules" "$UDEV_DEST"
+  if command -v udevadm >/dev/null 2>&1; then
+    udevadm control --reload-rules
+  else
+    warn "udevadm niet gevonden; voer handmatig een reload uit."
+  fi
+}
+
+install_logrotate() {
+  if [[ ! -f "$SCRIPT_DIR/logrotate/photoframe" ]]; then
+    die "logrotate/photoframe ontbreekt"
+  fi
+  log "Installeer logrotate-config"
+  install -Dm0644 "$SCRIPT_DIR/logrotate/photoframe" "$LOGROTATE_DEST"
+}
+
+create_env_file() {
+  if [[ -f "$ENV_FILE" ]]; then
+    warn "$ENV_FILE bestaat al; sla aanmaken over."
+    return
+  fi
+  log "Maak standaard .env-bestand in $ENV_FILE"
+  cat >"$ENV_FILE" <<EOF_ENV
+# Inky Photoframe dashboard configuratie
+PHOTOF_HOST=0.0.0.0
+PHOTOF_PORT=8080
+PHOTOF_IMAGE_DIR=$IMAGE_DIR
+PHOTOF_ADMIN_TOKEN=
+PHOTOF_RATE_LIMIT=30
+PHOTOF_LOG_FILE=$LOG_DIR/photoframe.log
+PHOTOF_LOG_LEVEL=info
+PHOTOF_EXTRA_ARGS=
+EOF_ENV
+  chmod 0640 "$ENV_FILE"
+  chown root:"$APP_GROUP" "$ENV_FILE"
+}
+
+print_summary() {
+  cat <<EOM
+
+Installatie voltooid.
+- Pas indien nodig $ENV_FILE aan.
+- Herlaad systemd en start de service met:
+    sudo systemctl enable --now $SERVICE_NAME
+- Controleer logbestanden in $LOG_DIR/photoframe.log
+EOM
+}
+
+main() {
+  require_root
+  ensure_commands
+  install_packages
+  ensure_group_user
+  create_directories
+  sync_sources
+  setup_venv
+  install_helper_scripts
+  create_env_file
+  install_systemd_unit
+  install_udev_rules
+  install_logrotate
+  print_summary
+}
+
+main "$@"

--- a/logrotate/photoframe
+++ b/logrotate/photoframe
@@ -1,0 +1,10 @@
+/var/log/photoframe/photoframe.log {
+    daily
+    rotate 7
+    missingok
+    notifempty
+    compress
+    delaycompress
+    copytruncate
+    create 0640 photoframe photoframe
+}

--- a/systemd/photoframe.service
+++ b/systemd/photoframe.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Inky Photoframe Dashboard
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=photoframe
+Group=photoframe
+EnvironmentFile=/etc/photoframe/photoframe.env
+WorkingDirectory=/opt/photoframe/app
+ExecStart=/opt/photoframe/bin/photoframe-server
+Restart=on-failure
+RestartSec=5
+RuntimeDirectory=photoframe
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=multi-user.target

--- a/udev/99-photoframe.rules
+++ b/udev/99-photoframe.rules
@@ -1,0 +1,3 @@
+SUBSYSTEM=="spidev", GROUP="photoframe", MODE="0660"
+SUBSYSTEM=="i2c-dev", GROUP="photoframe", MODE="0660"
+KERNEL=="fb*", GROUP="photoframe", MODE="0660"


### PR DESCRIPTION
## Summary
- add an `install.sh` helper that provisions Python 3.11, required directories, a virtualenv and deployment assets for the photoframe service
- provide the photoframe launch helper plus systemd, udev and logrotate templates for managed operation
- expand the README with installation, environment, testing and rollback instructions for the new deployment flow

## Testing
- `bash -n install.sh`
- `bash -n bin/photoframe-server`
- `SKIP_APT=1 SKIP_SYSTEMD=1 SKIP_UDEV=1 ./install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d0f99bdc70832c972f84eaf2b5eb55