### PR TITLE
Refactor widget base contract and add tests

### DIFF
--- a/server/api/render.py
+++ b/server/api/render.py
@@ -73,9 +73,9 @@ async def render_now(
         else:
             widget = state.widget_registry.get(payload.widget or "")
             target_size = inky_display.target_size()
-            data = await widget.fetch(payload.config or {}, state=state)
-            surface = Surface(target_size)
-            image = widget.render(surface, data)
+            context = await widget.fetch(payload.config or {}, state=state)
+            surface = Surface(target_size, theme=context.theme)
+            image = widget.render(surface, context)
             identifier = widget.slug
             source = "widget"
     except WidgetError as exc:

--- a/server/api/widgets.py
+++ b/server/api/widgets.py
@@ -93,9 +93,9 @@ async def test_widget(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
     config = payload.config or {}
-    data = await widget.fetch(config, state=state)
-    surface = Surface(inky_display.target_size())
-    image = widget.render(surface, data)
+    context = await widget.fetch(config, state=state)
+    surface = Surface(inky_display.target_size(), theme=context.theme)
+    image = widget.render(surface, context)
     buffer = io.BytesIO()
     image.save(buffer, format="PNG")
     preview = base64.b64encode(buffer.getvalue()).decode("ascii")

--- a/server/widgets/__init__.py
+++ b/server/widgets/__init__.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-from .base import Surface, WidgetBase, WidgetError, WidgetField, WidgetRegistry
+from .base import WidgetBase, WidgetError, WidgetField, WidgetRenderContext
 from .clock import ClockWidget
 from .message import MessageWidget
+from .registry import WidgetRegistry
 from .surface import Surface, Theme
 
 __all__ = [
@@ -9,6 +10,7 @@ __all__ = [
     "WidgetBase",
     "WidgetError",
     "WidgetField",
+    "WidgetRenderContext",
     "WidgetRegistry",
     "Theme",
     "ClockWidget",

--- a/server/widgets/base.py
+++ b/server/widgets/base.py
@@ -1,36 +1,18 @@
 from __future__ import annotations
 
-
+import json
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, Dict, Mapping, Sequence, TYPE_CHECKING
 
 from PIL import Image
 
-from .surface import Surface, Theme
-import json
-from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Optional, Sequence, TYPE_CHECKING
-
-from PIL import Image, ImageDraw
-
 from ..cache import CacheStore
+from .surface import Surface, Theme
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..app import AppState
 
-__all__ = [
-    "WidgetError",
-    "WidgetField",
-    "WidgetBase",
-    "WidgetRegistry",
-]
-
-
-@dataclass
-=======
-    "Surface",
-    "WidgetBase",
-]
+__all__ = ["WidgetError", "WidgetField", "WidgetRenderContext", "WidgetBase"]
 
 
 class WidgetError(RuntimeError):
@@ -47,18 +29,17 @@ class WidgetField:
     description: str | None = None
 
 
-class WidgetError(RuntimeError):
-    pass
+@dataclass(slots=True)
+class WidgetRenderContext:
+    """Container describing the data required to render a widget."""
+
+    data: Any
+    config: Mapping[str, Any]
+    theme: Theme
 
 
 class WidgetBase:
     """Base class for widgets exposing configuration metadata and rendering."""
-
-    slug: str
-    name: str
-    description: str
-    fields: Sequence[WidgetField]
-    default_config: Mapping[str, Any]
 
     def __init__(
         self,
@@ -68,12 +49,19 @@ class WidgetBase:
         description: str,
         fields: Sequence[WidgetField] | None = None,
         default_config: Mapping[str, Any] | None = None,
+        cache_ttl: float = 30.0,
+        cache_stale_ttl: float | None = None,
     ) -> None:
+        if not slug:
+            raise WidgetError(f"Widget {self.__class__.__name__} must define a slug")
         self.slug = slug
         self.name = name
         self.description = description
         self.fields = tuple(fields or ())
         self.default_config = dict(default_config or {})
+        self.cache_ttl = float(cache_ttl)
+        self.cache_stale_ttl = cache_stale_ttl
+        self._cache: CacheStore | None = None
 
     # -- configuration -------------------------------------------------
     def resolve_config(self, config: Mapping[str, Any] | None) -> Dict[str, Any]:
@@ -88,93 +76,9 @@ class WidgetBase:
     def get_theme(self, config: Mapping[str, Any]) -> Theme:
         return Theme.default()
 
-    # -- data lifecycle ------------------------------------------------
-    def fetch(self, config: Mapping[str, Any]) -> Any:
-        return None
-
-    def draw(self, surface: Surface, data: Any, config: Mapping[str, Any]) -> None:
-        raise NotImplementedError
-
-    def render(self, config: Mapping[str, Any] | None, size: tuple[int, int]) -> Image.Image:
-        resolved = self.resolve_config(config)
-        data = self.fetch(resolved)
-        theme = self.get_theme(resolved)
-        surface = Surface(size=size, theme=theme)
-        self.draw(surface, data, resolved)
-        return surface.image
-
-
-class WidgetRegistry:
-    def __init__(self) -> None:
-        self._items: MutableMapping[str, WidgetBase] = {}
-
-    def register(self, widget: WidgetBase) -> None:
-        self._items[widget.slug] = widget
-
-    def get(self, slug: str) -> WidgetBase:
-        try:
-            return self._items[slug]
-        except KeyError as exc:  # pragma: no cover - defensive
-            raise WidgetError(f"Onbekende widget: {slug}") from exc
-
-    def list(self) -> Iterable[WidgetBase]:
-        return self._items.values()
-
-    def __contains__(self, slug: str) -> bool:
-        return slug in self._items
-    default: Optional[Any] = None
-    description: Optional[str] = None
-
-
-class Surface:
-    """Simple drawing surface backed by a Pillow image."""
-
-    def __init__(self, size: tuple[int, int], mode: str = "RGB", background: Any = "white") -> None:
-        self.size = size
-        self.mode = mode
-        self.background = background
-        self.image = Image.new(mode, size, color=background)
-        self.draw = ImageDraw.Draw(self.image)
-
-    @property
-    def width(self) -> int:
-        return self.size[0]
-
-    @property
-    def height(self) -> int:
-        return self.size[1]
-
-    def clear(self, color: Any | None = None) -> None:
-        color = self.background if color is None else color
-        self.image.paste(color, [0, 0, self.width, self.height])
-
-
-class WidgetBase:
-    """Base class for widgets that can render onto a :class:`Surface`."""
-
-    slug: str = ""
-    name: str = ""
-    description: str = ""
-    fields: Sequence[WidgetField] = ()
-    default_config: Mapping[str, Any] = {}
-    cache_ttl: float = 30.0
-    cache_stale_ttl: Optional[float] = None
-
-    def __init__(self) -> None:
-        if not self.slug:
-            raise WidgetError(f"Widget {self.__class__.__name__} must define a slug")
-        self.fields = list(self.fields)
-        self.default_config = dict(self.default_config)
-        self._cache: CacheStore | None = None
-
+    # -- caching -------------------------------------------------------
     def set_cache(self, cache: CacheStore | None) -> None:
         self._cache = cache
-
-    def build_config(self, config: Mapping[str, Any] | None) -> Dict[str, Any]:
-        merged: Dict[str, Any] = dict(self.default_config)
-        if config:
-            merged.update(config)
-        return merged
 
     def cache_key(self, config: Mapping[str, Any]) -> str:
         return json.dumps(config, sort_keys=True, default=str, ensure_ascii=False)
@@ -182,32 +86,57 @@ class WidgetBase:
     def cache_namespace(self) -> str:
         return self.slug
 
+    # -- data lifecycle ------------------------------------------------
     async def fetch(
         self,
         config: Mapping[str, Any] | None,
         *,
         state: "AppState" | None = None,
-    ) -> Any:
-        merged_config = self.build_config(config)
+    ) -> WidgetRenderContext:
+        resolved = self.resolve_config(config)
+        theme = self.get_theme(resolved)
 
-        async def loader() -> Any:
-            return await self._fetch(merged_config, state=state)
+        async def loader() -> WidgetRenderContext:
+            data = await self._fetch(resolved, state=state)
+            return WidgetRenderContext(data=data, config=resolved, theme=theme)
 
         if self._cache is None:
             return await loader()
 
-        ttl = float(max(self.cache_ttl, 0.0))
-        stale_ttl = float(max(self.cache_stale_ttl or ttl * 2, ttl))
+        ttl = max(self.cache_ttl, 0.0)
+        stale_ttl = self.cache_stale_ttl
+        if stale_ttl is None:
+            stale_ttl = ttl * 2
+        stale_ttl = max(stale_ttl, ttl)
+
         return await self._cache.get_or_load(
             self.cache_namespace(),
-            self.cache_key(merged_config),
+            self.cache_key(resolved),
             loader,
-            ttl,
-            stale_ttl,
+            float(ttl),
+            float(stale_ttl),
         )
 
-    async def _fetch(self, config: Mapping[str, Any], state: "AppState" | None = None) -> Any:
-        return config
+    async def _fetch(
+        self,
+        config: Mapping[str, Any],
+        *,
+        state: "AppState" | None = None,
+    ) -> Any:
+        return None
 
-    def render(self, surface: Surface, data: Any) -> Image.Image:
+    def draw(self, surface: Surface, data: Any, config: Mapping[str, Any]) -> None:
         raise NotImplementedError
+
+    def render(self, surface: Surface, result: WidgetRenderContext | Any) -> Image.Image:
+        if isinstance(result, WidgetRenderContext):
+            context = result
+        else:  # pragma: no cover - backwards compatibility
+            context = WidgetRenderContext(
+                data=result,
+                config=self.default_config,
+                theme=surface.theme,
+            )
+
+        self.draw(surface, context.data, context.config)
+        return surface.image

--- a/server/widgets/clock.py
+++ b/server/widgets/clock.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 import datetime as _dt
 import locale
 from contextlib import contextmanager
-from typing import Any, Mapping
+from typing import Any, Mapping, TYPE_CHECKING
 
 from .base import WidgetBase, WidgetField
 from .surface import Surface
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..app import AppState
 
 __all__ = ["ClockWidget"]
 
@@ -62,7 +65,12 @@ class ClockWidget(WidgetBase):
             default_config={"use_24h": True, "locale": "nl_NL"},
         )
 
-    def fetch(self, config: Mapping[str, Any]) -> _dt.datetime:
+    async def _fetch(
+        self,
+        config: Mapping[str, Any],
+        *,
+        state: "AppState" | None = None,
+    ) -> _dt.datetime:
         return _dt.datetime.now()
 
     def draw(self, surface: Surface, data: _dt.datetime, config: Mapping[str, Any]) -> None:

--- a/server/widgets/message.py
+++ b/server/widgets/message.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
-from typing import Mapping
+
+from typing import Mapping, TYPE_CHECKING
 
 from .base import WidgetBase, WidgetField
 from .surface import Surface
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..app import AppState
 
 __all__ = ["MessageWidget"]
 
@@ -26,7 +30,12 @@ class MessageWidget(WidgetBase):
             default_config={"text": "Photoframe"},
         )
 
-    def fetch(self, config: Mapping[str, str]) -> str:
+    async def _fetch(
+        self,
+        config: Mapping[str, str],
+        *,
+        state: "AppState" | None = None,
+    ) -> str:
         text = str(config.get("text") or "Photoframe")
         return text.strip() or "Photoframe"
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "server" not in sys.modules:
+    server_module = types.ModuleType("server")
+    server_module.__path__ = [str(ROOT / "server")]
+    server_module.__spec__ = ModuleSpec("server", loader=None, is_package=True)
+    sys.modules["server"] = server_module
+
+from server.widgets import Surface, WidgetRegistry, WidgetRenderContext
+from server.widgets.message import MessageWidget
+
+
+def test_registry_fetch_and_render() -> None:
+    registry = WidgetRegistry()
+    widgets = list(registry.list())
+    slugs = {widget.slug for widget in widgets}
+    assert {"message", "clock"}.issubset(slugs)
+
+    async def run() -> None:
+        for widget in widgets:
+            context = await widget.fetch({}, state=None)
+            assert isinstance(context, WidgetRenderContext)
+            surface = Surface((400, 300), theme=context.theme)
+            image = widget.render(surface, context)
+            assert image.size == (400, 300)
+
+    asyncio.run(run())
+
+
+def test_message_widget_uses_default_text() -> None:
+    widget = MessageWidget()
+
+    async def run() -> None:
+        context = await widget.fetch({"text": "   "}, state=None)
+        assert context.data == "Photoframe"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- simplify `WidgetBase` to expose a consistent constructor and return a `WidgetRenderContext` for rendering
- update the built-in widgets and API endpoints to use the new fetch/render flow
- add regression tests that load the widget registry and ensure widgets fetch and render successfully

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d10344f3f0832cb8e977bb9e8590d8