### PR TITLE
Ensure widget registry auto-discovery works with cache

### DIFF
--- a/server/widgets/__init__.py
+++ b/server/widgets/__init__.py
@@ -20,7 +20,6 @@ __all__ = [
 
 
 def create_default_registry() -> WidgetRegistry:
-    registry = WidgetRegistry()
-    registry.register(MessageWidget())
-    registry.register(ClockWidget())
-    return registry
+    """Return a registry pre-populated with built-in widgets."""
+
+    return WidgetRegistry()

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -16,6 +16,7 @@ if "server" not in sys.modules:
     server_module.__spec__ = ModuleSpec("server", loader=None, is_package=True)
     sys.modules["server"] = server_module
 
+from server.cache import CacheStore
 from server.widgets import Surface, WidgetRegistry, WidgetRenderContext
 from server.widgets.message import MessageWidget
 
@@ -35,6 +36,15 @@ def test_registry_fetch_and_render() -> None:
             assert image.size == (400, 300)
 
     asyncio.run(run())
+
+
+def test_registry_with_cache_discovers_builtin_widgets() -> None:
+    cache = CacheStore()
+    registry = WidgetRegistry(cache=cache)
+
+    slugs = {widget.slug for widget in registry.list()}
+
+    assert {"message", "clock"}.issubset(slugs)
 
 
 def test_message_widget_uses_default_text() -> None:


### PR DESCRIPTION
## Summary
- ensure the widget package re-exports WidgetRegistry from the dedicated module
- rely on the registry's built-in discovery for the default registry helper
- add a test covering auto-discovery when a cache store is provided

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d105eae4c4832c9bdde98ce4c37536