### PR TITLE
Align cache helper signatures with Path-based API

### DIFF
--- a/server/cache/__init__.py
+++ b/server/cache/__init__.py
@@ -185,7 +185,7 @@ def _parse_cache_config(text: str, suffix: str) -> Dict[str, Any]:
         return dict(data or {})
 
 
-def load_cache_settings(path: Path | str, base_dir: Path | str) -> CacheSettings:
+def load_cache_settings(path: Path, base_dir: Path) -> CacheSettings:
     """Load :class:`CacheSettings` from ``path``.
 
     ``path`` may point to a YAML or JSON configuration file. When the file is


### PR DESCRIPTION
## Summary
- restrict the load_cache_settings helper signature to use Path parameters

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d108da2920832ca527709873b7a43d