### PR TITLE
Add clock section with live updates for photoframe UI

### DIFF
--- a/server/static/main.js
+++ b/server/static/main.js
@@ -62,6 +62,37 @@ async function refreshList() {
   }
 }
 
+function getISOWeekString(date) {
+  const target = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNumber = target.getUTCDay() || 7;
+  target.setUTCDate(target.getUTCDate() + 4 - dayNumber);
+  const yearStart = new Date(Date.UTC(target.getUTCFullYear(), 0, 1));
+  const weekNumber = Math.ceil(((target - yearStart) / 86400000 + 1) / 7);
+  return `${target.getUTCFullYear()}-W${String(weekNumber).padStart(2, '0')}`;
+}
+
+function updateClock() {
+  const clockTime = document.getElementById('clockTime');
+  const clockDate = document.getElementById('clockDate');
+  const clockWeek = document.getElementById('clockWeek');
+  if (!clockTime || !clockDate || !clockWeek) return;
+
+  const now = new Date();
+  const locale = navigator.language || undefined;
+  const time = now.toLocaleTimeString(locale, { hour: '2-digit', minute: '2-digit' });
+  const date = now.toLocaleDateString(locale, {
+    weekday: 'long',
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+  const week = getISOWeekString(now);
+
+  clockTime.textContent = time;
+  clockDate.textContent = date;
+  clockWeek.textContent = week;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const uploadForm = document.getElementById('uploadForm');
   uploadForm.addEventListener('submit', async (event) => {
@@ -97,5 +128,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   refreshStatus();
   refreshList();
+  updateClock();
   setInterval(refreshStatus, 5000);
+  setInterval(updateClock, 60000);
 });

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -18,6 +18,47 @@ h1 {
   margin: 16px 0;
 }
 
+.clock-section {
+  border: 2px solid #000;
+  border-radius: 12px;
+  background: #fff;
+  padding: 20px;
+}
+
+.clock-display {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  color: #000;
+}
+
+.clock-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.clock-label {
+  font-size: 0.95rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #111;
+  font-weight: 600;
+}
+
+.clock-value {
+  font-size: 2.4rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: #000;
+}
+
+.clock-date {
+  font-size: 1.6rem;
+  line-height: 1.3;
+}
+
 .row {
   display: flex;
   gap: 8px;
@@ -64,4 +105,19 @@ input[type="number"] {
 
 small {
   color: #666;
+}
+
+@media (max-width: 600px) {
+  .row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .clock-value {
+    font-size: 2rem;
+  }
+
+  .clock-date {
+    font-size: 1.4rem;
+  }
 }

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -4,6 +4,24 @@
       <div id="status"><small>Loading status…</small></div>
     </div>
 
+    <div class="section clock-section">
+      <h2>Klok</h2>
+      <div class="clock-display" aria-live="polite" aria-atomic="true">
+        <div class="clock-row">
+          <span class="clock-label">Tijd</span>
+          <span id="clockTime" class="clock-value">--:--</span>
+        </div>
+        <div class="clock-row">
+          <span class="clock-label">Datum</span>
+          <span id="clockDate" class="clock-value clock-date">-- -- ----</span>
+        </div>
+        <div class="clock-row">
+          <span class="clock-label">Week</span>
+          <span id="clockWeek" class="clock-value">W--</span>
+        </div>
+      </div>
+    </div>
+
     <div class="section">
       <h2>Upload</h2>
       <form id="uploadForm">


### PR DESCRIPTION
## Summary
- add a dedicated clock section with placeholders for time, date, and ISO week
- compute and update the new clock elements each minute in the dashboard script
- style the clock for high-contrast legibility on e-ink displays

## Testing
- pytest *(fails: missing fastapi and pillow dependencies in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10d4db410832cb1b93d2431287613