### PR TITLE
Add weather endpoint and dashboard panel

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,5 +1,5 @@
 """API routers for the photoframe FastAPI application."""
 
-from . import config, logs, render, status, widgets
+from . import config, logs, render, status, weather, widgets
 
-__all__ = ["config", "logs", "render", "status", "widgets"]
+__all__ = ["config", "logs", "render", "status", "weather", "widgets"]

--- a/server/api/weather.py
+++ b/server/api/weather.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+from urllib import error as urlerror
+from urllib import parse, request
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from ..app import AppState, get_app_state
+
+router = APIRouter(tags=["weather"])
+
+
+class WeatherCurrent(BaseModel):
+    time: str = Field(..., description="Timestamp of the observation in ISO format")
+    temperature: Optional[float] = Field(None, description="Current air temperature")
+    windspeed: Optional[float] = Field(None, description="Wind speed in km/h")
+    winddirection: Optional[float] = Field(None, description="Wind direction in degrees")
+    weathercode: Optional[int] = Field(None, description="Open-Meteo weather condition code")
+
+
+class WeatherDay(BaseModel):
+    date: str = Field(..., description="Date of the forecast day")
+    weathercode: Optional[int] = Field(None, description="Open-Meteo weather condition code")
+    temperature_max: Optional[float] = Field(None, description="Daily maximum temperature")
+    temperature_min: Optional[float] = Field(None, description="Daily minimum temperature")
+    precipitation_probability: Optional[float] = Field(
+        None, description="Mean precipitation probability in percent"
+    )
+
+
+class WeatherUnits(BaseModel):
+    temperature: str = Field(..., description="Unit for temperature values")
+    windspeed: str = Field(..., description="Unit for wind speed values")
+    precipitation_probability: str = Field(
+        "%", description="Unit for precipitation probability"
+    )
+
+
+class WeatherResponse(BaseModel):
+    latitude: float
+    longitude: float
+    location_label: str
+    timezone: str
+    fetched_at: str
+    source: str
+    current: WeatherCurrent
+    daily: List[WeatherDay]
+    units: WeatherUnits
+
+
+@dataclass
+class _WeatherRequest:
+    latitude: float
+    longitude: float
+    days: int
+
+    def cache_key(self) -> tuple[float, float, int]:
+        # Reduce cache cardinality by rounding to two decimal places.
+        return (round(self.latitude, 2), round(self.longitude, 2), self.days)
+
+
+async def _fetch_open_meteo(payload: _WeatherRequest) -> Dict[str, Any]:
+    params = {
+        "latitude": f"{payload.latitude:.4f}",
+        "longitude": f"{payload.longitude:.4f}",
+        "current_weather": "true",
+        "daily": [
+            "weathercode",
+            "temperature_2m_max",
+            "temperature_2m_min",
+            "precipitation_probability_mean",
+        ],
+        "timezone": "auto",
+    }
+    if payload.days:
+        params["forecast_days"] = str(payload.days)
+
+    query = parse.urlencode(params, doseq=True)
+    url = f"https://api.open-meteo.com/v1/forecast?{query}"
+
+    def _loader() -> Dict[str, Any]:
+        req = request.Request(
+            url,
+            headers={
+                "User-Agent": "photoframe-weather/1.0 (+https://github.com/)",
+                "Accept": "application/json",
+            },
+        )
+        with request.urlopen(req, timeout=15) as response:  # type: ignore[arg-type]
+            if response.status != 200:
+                raise HTTPException(
+                    status_code=502,
+                    detail="weather-service-error",
+                )
+            data = response.read()
+        try:
+            return json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive guard
+            raise HTTPException(status_code=502, detail="invalid-weather-response") from exc
+
+    try:
+        return await asyncio.to_thread(_loader)
+    except HTTPException:
+        raise
+    except urlerror.URLError as exc:  # pragma: no cover - network errors
+        raise HTTPException(status_code=502, detail="weather-service-unavailable") from exc
+
+
+def _extract_index(sequence: Optional[List[Any]], index: int) -> Optional[Any]:
+    if not sequence:
+        return None
+    try:
+        return sequence[index]
+    except (IndexError, TypeError):
+        return None
+
+
+def _normalise_response(payload: _WeatherRequest, data: Dict[str, Any]) -> Dict[str, Any]:
+    current_raw = data.get("current_weather") or {}
+    daily_raw = data.get("daily") or {}
+    daily_units = data.get("daily_units") or {}
+    current_units = data.get("current_weather_units") or {}
+
+    times = daily_raw.get("time") or []
+    forecast: List[Dict[str, Any]] = []
+    for idx, date in enumerate(times):
+        forecast.append(
+            {
+                "date": date,
+                "weathercode": _extract_index(daily_raw.get("weathercode"), idx),
+                "temperature_max": _extract_index(daily_raw.get("temperature_2m_max"), idx),
+                "temperature_min": _extract_index(daily_raw.get("temperature_2m_min"), idx),
+                "precipitation_probability": _extract_index(
+                    daily_raw.get("precipitation_probability_mean"), idx
+                ),
+            }
+        )
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    return {
+        "latitude": data.get("latitude", payload.latitude),
+        "longitude": data.get("longitude", payload.longitude),
+        "location_label": f"{payload.latitude:.2f}°, {payload.longitude:.2f}°",
+        "timezone": data.get("timezone", "UTC"),
+        "fetched_at": now,
+        "source": "open-meteo.com",
+        "current": {
+            "time": current_raw.get("time", now),
+            "temperature": current_raw.get("temperature"),
+            "windspeed": current_raw.get("windspeed"),
+            "winddirection": current_raw.get("winddirection"),
+            "weathercode": current_raw.get("weathercode"),
+        },
+        "daily": forecast,
+        "units": {
+            "temperature": daily_units.get("temperature_2m_max")
+            or current_units.get("temperature")
+            or "°C",
+            "windspeed": current_units.get("windspeed", "km/h"),
+            "precipitation_probability": daily_units.get(
+                "precipitation_probability_mean", "%"
+            ),
+        },
+    }
+
+
+async def _load_weather(
+    request_payload: _WeatherRequest,
+    loader: Callable[[
+        _WeatherRequest,
+    ], Awaitable[Dict[str, Any]]],
+) -> Dict[str, Any]:
+    raw = await loader(request_payload)
+    return _normalise_response(request_payload, raw)
+
+
+@router.get("/weather", response_model=WeatherResponse)
+async def weather(
+    latitude: float = Query(52.37, ge=-90.0, le=90.0),
+    longitude: float = Query(4.89, ge=-180.0, le=180.0),
+    days: int = Query(5, ge=1, le=14),
+    state: AppState = Depends(get_app_state),
+) -> WeatherResponse:
+    payload = _WeatherRequest(latitude=latitude, longitude=longitude, days=days)
+
+    async def _loader() -> Dict[str, Any]:
+        return await _load_weather(payload, _fetch_open_meteo)
+
+    try:
+        cached = await state.cache.get_or_load(
+            "weather",
+            payload.cache_key(),
+            _loader,
+            ttl=600.0,
+            stale_ttl=1800.0,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=502, detail="weather-unavailable") from exc
+
+    return WeatherResponse(**cached)

--- a/server/app.py
+++ b/server/app.py
@@ -175,11 +175,12 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         return await index(request, state)
 
     from .api import config as config_routes
-    from .api import logs, render, status, widgets
+    from .api import logs, render, status, weather, widgets
 
     app.include_router(status.router)
     app.include_router(render.router)
     app.include_router(config_routes.router)
+    app.include_router(weather.router)
     app.include_router(widgets.router)
     app.include_router(logs.router)
 

--- a/server/static/main.js
+++ b/server/static/main.js
@@ -1,3 +1,226 @@
+const WEATHER_CACHE_KEY = 'weather:last-response';
+const WEATHER_CACHE_TTL = 10 * 60 * 1000; // 10 minuten
+const WEATHER_CACHE_MAX_AGE = WEATHER_CACHE_TTL * 3;
+
+const WEATHER_CODES = {
+  0: { icon: '☀', label: 'Helder' },
+  1: { icon: '🌤', label: 'Meestal helder' },
+  2: { icon: '⛅', label: 'Gedeeltelijk bewolkt' },
+  3: { icon: '☁', label: 'Bewolkt' },
+  45: { icon: '🌫', label: 'Mist' },
+  48: { icon: '🌫', label: 'IJsmist' },
+  51: { icon: '🌦', label: 'Motregen licht' },
+  53: { icon: '🌦', label: 'Motregen' },
+  55: { icon: '🌧', label: 'Motregen zwaar' },
+  56: { icon: '🌧', label: 'Motregen ijzel' },
+  57: { icon: '🌧', label: 'Motregen zware ijzel' },
+  61: { icon: '🌦', label: 'Lichte regen' },
+  63: { icon: '🌧', label: 'Regen' },
+  65: { icon: '🌧', label: 'Zware regen' },
+  66: { icon: '🌧', label: 'IJzel' },
+  67: { icon: '🌧', label: 'Zware ijzel' },
+  71: { icon: '🌨', label: 'Lichte sneeuw' },
+  73: { icon: '🌨', label: 'Sneeuw' },
+  75: { icon: '❄', label: 'Zware sneeuw' },
+  77: { icon: '❄', label: 'Sneeuwkorrels' },
+  80: { icon: '🌦', label: 'Lichte buien' },
+  81: { icon: '🌧', label: 'Regenbuien' },
+  82: { icon: '🌧', label: 'Zware regenbuien' },
+  85: { icon: '🌨', label: 'Sneeuwbuien' },
+  86: { icon: '🌨', label: 'Zware sneeuwbuien' },
+  95: { icon: '⛈', label: 'Onweer' },
+  96: { icon: '⛈', label: 'Onweer met hagel' },
+  99: { icon: '⛈', label: 'Zwaar onweer' },
+};
+
+function describeWeather(code) {
+  return WEATHER_CODES[code] || { icon: '☁', label: 'Onbekend' };
+}
+
+function formatTime(value, timezone = 'UTC') {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    return date.toLocaleString('nl-NL', {
+      hour: '2-digit',
+      minute: '2-digit',
+      day: 'numeric',
+      month: 'short',
+      timeZone: timezone,
+    });
+  } catch (err) {
+    return value;
+  }
+}
+
+function formatDay(value, timezone = 'UTC') {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    return date.toLocaleDateString('nl-NL', {
+      weekday: 'short',
+      day: 'numeric',
+      month: 'short',
+      timeZone: timezone,
+    });
+  } catch (err) {
+    return value;
+  }
+}
+
+function loadWeatherCache() {
+  try {
+    const raw = localStorage.getItem(WEATHER_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object' || !parsed.data) return null;
+    return parsed;
+  } catch (err) {
+    return null;
+  }
+}
+
+function saveWeatherCache(data) {
+  try {
+    const payload = { timestamp: Date.now(), data };
+    localStorage.setItem(WEATHER_CACHE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    // Ignore storage errors (e.g. private browsing)
+  }
+}
+
+function renderWeather(data, options = {}) {
+  const panel = document.getElementById('weatherPanel');
+  if (!panel || !data) return;
+
+  const { stale = false, error = null } = options;
+  const statusEl = panel.querySelector('.weather-status');
+  const iconEl = panel.querySelector('.weather-icon');
+  const tempEl = panel.querySelector('.weather-temp');
+  const descEl = panel.querySelector('.weather-description');
+  const metaEl = panel.querySelector('.weather-meta');
+  const updatedEl = panel.querySelector('.weather-updated');
+  const forecastEl = panel.querySelector('.weather-forecast');
+  const units = data.units || {};
+
+  panel.classList.toggle('is-stale', Boolean(stale));
+
+  const descriptor = describeWeather(data.current?.weathercode);
+  const locationLabel = data.location_label || `${Number.parseFloat(data.latitude || 0).toFixed(2)}°, ${Number.parseFloat(data.longitude || 0).toFixed(2)}°`;
+
+  if (statusEl) {
+    const info = [`Bron: ${data.source || 'onbekend'}`, `Locatie ${locationLabel}`];
+    if (stale) info.push('Toont cache');
+    if (error) info.push(`Fout: ${error}`);
+    statusEl.textContent = info.join(' • ');
+  }
+  if (iconEl) iconEl.textContent = descriptor.icon;
+  if (tempEl) {
+    const temp = typeof data.current?.temperature === 'number'
+      ? `${Math.round(data.current.temperature)}${units.temperature || '°C'}`
+      : '—';
+    tempEl.textContent = temp;
+  }
+  if (descEl) descEl.textContent = descriptor.label;
+  if (metaEl) {
+    const parts = [];
+    if (typeof data.current?.windspeed === 'number') {
+      parts.push(`Wind ${Math.round(data.current.windspeed)} ${units.windspeed || 'km/h'}`);
+    }
+    if (data.current?.time) {
+      parts.push(`Gemeten ${formatTime(data.current.time, data.timezone)}`);
+    }
+    metaEl.textContent = parts.join(' • ') || 'Geen details beschikbaar';
+  }
+  if (updatedEl) {
+    updatedEl.textContent = `Laatst bijgewerkt: ${formatTime(data.fetched_at, data.timezone)}`;
+  }
+  if (forecastEl) {
+    forecastEl.innerHTML = '';
+    (data.daily || []).forEach((day) => {
+      const item = document.createElement('li');
+      item.className = 'weather-day';
+
+      const dayLabel = document.createElement('div');
+      dayLabel.className = 'day-label';
+      dayLabel.textContent = formatDay(day.date, data.timezone);
+
+      const dayIcon = document.createElement('div');
+      dayIcon.className = 'day-icon';
+      const dayDescriptor = describeWeather(day.weathercode);
+      dayIcon.textContent = dayDescriptor.icon;
+
+      const dayDesc = document.createElement('div');
+      dayDesc.className = 'day-desc';
+      dayDesc.textContent = dayDescriptor.label;
+
+      const dayTemp = document.createElement('div');
+      dayTemp.className = 'day-temp';
+      const max = typeof day.temperature_max === 'number'
+        ? `${Math.round(day.temperature_max)}${units.temperature || '°C'}`
+        : '—';
+      const min = typeof day.temperature_min === 'number'
+        ? `${Math.round(day.temperature_min)}${units.temperature || '°C'}`
+        : '—';
+      const precip = typeof day.precipitation_probability === 'number'
+        ? ` • Neerslag ${Math.round(day.precipitation_probability)}${units.precipitation_probability || '%'}`
+        : '';
+      dayTemp.textContent = `${max} / ${min}${precip}`;
+
+      item.appendChild(dayLabel);
+      item.appendChild(dayIcon);
+      item.appendChild(dayDesc);
+      item.appendChild(dayTemp);
+      forecastEl.appendChild(item);
+    });
+    if (!forecastEl.children.length) {
+      const empty = document.createElement('li');
+      empty.className = 'weather-day';
+      empty.textContent = 'Geen verwachting beschikbaar';
+      forecastEl.appendChild(empty);
+    }
+  }
+}
+
+async function refreshWeather(force = false) {
+  const panel = document.getElementById('weatherPanel');
+  if (!panel) return;
+
+  const lat = Number.parseFloat(panel.dataset.lat || '52.37');
+  const lon = Number.parseFloat(panel.dataset.lon || '4.89');
+  const days = Number.parseInt(panel.dataset.days || '5', 10);
+  const cached = loadWeatherCache();
+  const now = Date.now();
+
+  if (!force && cached && now - cached.timestamp < WEATHER_CACHE_TTL) {
+    renderWeather(cached.data);
+    return;
+  }
+
+  const statusEl = panel.querySelector('.weather-status');
+  if (statusEl) {
+    statusEl.textContent = 'Weersinformatie wordt bijgewerkt…';
+  }
+
+  try {
+    const url = `/weather?latitude=${lat}&longitude=${lon}&days=${days}`;
+    const response = await fetch(url, { headers: { 'Accept': 'application/json' } });
+    if (!response.ok) {
+      throw new Error(`status ${response.status}`);
+    }
+    const data = await response.json();
+    renderWeather(data);
+    saveWeatherCache(data);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'onbekende fout';
+    if (cached && now - cached.timestamp < WEATHER_CACHE_MAX_AGE) {
+      renderWeather(cached.data, { stale: true, error: message });
+    } else if (statusEl) {
+      statusEl.textContent = `Geen weerdata beschikbaar (${message})`;
+    }
+  }
+}
+
 async function getJSON(path) {
   const response = await fetch(path);
   if (!response.ok) {
@@ -98,4 +321,15 @@ document.addEventListener('DOMContentLoaded', () => {
   refreshStatus();
   refreshList();
   setInterval(refreshStatus, 5000);
+
+  const cachedWeather = loadWeatherCache();
+  if (cachedWeather && Date.now() - cachedWeather.timestamp < WEATHER_CACHE_MAX_AGE) {
+    renderWeather(cachedWeather.data, { stale: true });
+  }
+  const refreshButton = document.getElementById('weatherRefresh');
+  if (refreshButton) {
+    refreshButton.addEventListener('click', () => refreshWeather(true));
+  }
+  refreshWeather();
+  setInterval(() => refreshWeather(), 15 * 60 * 1000);
 });

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -1,7 +1,9 @@
 body {
-  font-family: system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  font-family: "IBM Plex Sans", "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
   margin: 0;
   background: #ffffff;
+  color: #111111;
+  letter-spacing: 0.01em;
 }
 
 main.page {
@@ -12,10 +14,114 @@ main.page {
 
 h1 {
   margin: 0 0 8px 0;
+  font-weight: 600;
+  letter-spacing: 0.04em;
 }
 
 .section {
   margin: 16px 0;
+}
+
+.weather-panel {
+  border: 2px solid #111111;
+  border-radius: 14px;
+  padding: 16px;
+  background: #ffffff;
+  box-shadow: 0 2px 0 0 #111111;
+}
+
+.weather-panel.is-stale {
+  border-style: dashed;
+  box-shadow: none;
+}
+
+.weather-status {
+  font-variant: all-small-caps;
+  letter-spacing: 0.08em;
+  color: #333333;
+  margin-bottom: 12px;
+}
+
+.weather-current {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 12px;
+}
+
+.weather-current-details {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.weather-icon {
+  font-size: 48px;
+  line-height: 1;
+}
+
+.weather-temp {
+  font-size: 36px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+}
+
+.weather-description {
+  font-size: 18px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+}
+
+.weather-meta,
+.weather-updated {
+  color: #444444;
+  font-size: 14px;
+}
+
+.weather-controls {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.weather-controls button {
+  flex-shrink: 0;
+}
+
+.weather-forecast {
+  list-style: none;
+  padding: 0;
+  margin: 16px 0 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 12px;
+}
+
+.weather-day {
+  border: 1px solid #333333;
+  border-radius: 10px;
+  padding: 12px;
+  background: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.weather-day .day-label {
+  font-variant: small-caps;
+  letter-spacing: 0.08em;
+}
+
+.weather-day .day-icon {
+  font-size: 26px;
+}
+
+.weather-day .day-temp {
+  font-size: 16px;
+}
+
+.weather-day .day-desc {
+  font-size: 14px;
+  color: #333333;
 }
 
 .row {

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -4,6 +4,26 @@
       <div id="status"><small>Loading status…</small></div>
     </div>
 
+    <div class="section weather-section">
+      <h2>Weer</h2>
+      <div class="weather-panel" id="weatherPanel" data-lat="52.37" data-lon="4.89" data-days="5">
+        <div class="weather-status" role="status">Weersinformatie wordt geladen…</div>
+        <div class="weather-current" aria-live="polite">
+          <div class="weather-icon" aria-hidden="true">☁</div>
+          <div class="weather-current-details">
+            <div class="weather-temp"></div>
+            <div class="weather-description"></div>
+            <div class="weather-meta"></div>
+          </div>
+        </div>
+        <div class="weather-controls row">
+          <button id="weatherRefresh" type="button">Ververs weer</button>
+          <small class="weather-updated" aria-live="polite">Laatst bijgewerkt: —</small>
+        </div>
+        <ul class="weather-forecast" aria-label="Meerdaagse verwachting"></ul>
+      </div>
+    </div>
+
     <div class="section">
       <h2>Upload</h2>
       <form id="uploadForm">


### PR DESCRIPTION
## Summary
- add a cached `/weather` endpoint that retrieves Open-Meteo current and multi-day forecasts
- integrate a weather panel in the dashboard with resilient fetch logic and localStorage caching
- style the new panel with high-contrast typography and iconography suitable for e-ink displays

## Testing
- pytest *(fails: missing fastapi/Pillow dependencies in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10d760078832c9ec296244c11b975