### PR TITLE
Add news feed endpoint and UI section

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import time
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from email.utils import parsedate_to_datetime
+from html import unescape
+from html.parser import HTMLParser
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterable, Optional
+from urllib.error import URLError
+from urllib.request import Request as URLRequest
+from urllib.request import urlopen
+from xml.etree import ElementTree
 
 from fastapi import Depends, FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 
@@ -23,6 +32,11 @@ DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8080
 DEFAULT_IMAGE_DIR = Path("/image")
 DEFAULT_ADMIN_RATE_LIMIT = 30
+DEFAULT_NEWS_FEEDS: tuple[str, ...] = (
+    "https://www.nu.nl/rss/Algemeen",
+    "https://tweakers.net/feeds/nieuws.xml",
+    "https://feeds.bbci.co.uk/news/world/rss.xml",
+)
 
 
 def _model_dump(model: Any, **kwargs: Any) -> dict:
@@ -54,6 +68,222 @@ class RateLimiter:
             if len(timestamps) >= self.limit:
                 raise RuntimeError("rate-limit-exceeded")
             timestamps.append(now)
+
+
+class _HTMLStripper(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self._parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:  # pragma: no cover - trivial
+        if data:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        return "".join(self._parts)
+
+
+def _strip_tag(tag: str) -> str:
+    return tag.split("}", 1)[-1] if "}" in tag else tag
+
+
+def _child_itertext(element: ElementTree.Element, name: str) -> Optional[str]:
+    for child in element:
+        if _strip_tag(child.tag).lower() == name:
+            return "".join(child.itertext()).strip()
+    return None
+
+
+def _child_attr(element: ElementTree.Element, name: str, attribute: str) -> Optional[str]:
+    for child in element:
+        if _strip_tag(child.tag).lower() == name:
+            value = child.get(attribute)
+            if value:
+                return value.strip()
+    return None
+
+
+def _parse_datetime(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    text = value.strip()
+    try:
+        parsed = parsedate_to_datetime(text)
+        if parsed is not None:
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=timezone.utc)
+            return parsed.astimezone(timezone.utc)
+    except (TypeError, ValueError):
+        pass
+    # fallback for ISO 8601
+    try:
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        parsed_iso = datetime.fromisoformat(text)
+        if parsed_iso.tzinfo is None:
+            parsed_iso = parsed_iso.replace(tzinfo=timezone.utc)
+        return parsed_iso.astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+def _clean_text(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    stripper = _HTMLStripper()
+    try:
+        stripper.feed(value)
+        stripper.close()
+    except Exception:
+        return " ".join(value.split())
+    cleaned = unescape(stripper.get_text())
+    return " ".join(cleaned.split())
+
+
+def _summarise(text: str, max_length: int = 240) -> str:
+    if len(text) <= max_length:
+        return text
+    truncated = text[: max_length + 1]
+    if " " in truncated:
+        truncated = truncated.rsplit(" ", 1)[0]
+    return truncated.rstrip(".,;:-") + "…"
+
+
+def _parse_rss_feed(root: ElementTree.Element, source_url: str) -> Iterable[dict[str, Any]]:
+    channel = None
+    for child in root:
+        if _strip_tag(child.tag).lower() == "channel":
+            channel = child
+            break
+    if channel is None:
+        return []
+    source_name = _child_itertext(channel, "title") or source_url
+    items: list[dict[str, Any]] = []
+    for item in channel:
+        if _strip_tag(item.tag).lower() != "item":
+            continue
+        title = _child_itertext(item, "title") or "(zonder titel)"
+        link = _child_itertext(item, "link") or source_url
+        description = (
+            _child_itertext(item, "description")
+            or _child_itertext(item, "summary")
+            or ""
+        )
+        pub = _parse_datetime(
+            _child_itertext(item, "pubDate")
+            or _child_itertext(item, "published")
+            or _child_itertext(item, "updated")
+        )
+        cleaned = _clean_text(description)
+        items.append(
+            {
+                "title": unescape(title.strip()),
+                "link": link.strip(),
+                "summary": _summarise(cleaned) if cleaned else "",
+                "source": source_name,
+                "published_at": pub.isoformat().replace("+00:00", "Z") if pub else None,
+            }
+        )
+    return items
+
+
+def _parse_atom_feed(root: ElementTree.Element, source_url: str) -> Iterable[dict[str, Any]]:
+    source_name = _child_itertext(root, "title") or source_url
+    items: list[dict[str, Any]] = []
+    for entry in root:
+        if _strip_tag(entry.tag).lower() != "entry":
+            continue
+        title = _child_itertext(entry, "title") or "(zonder titel)"
+        link = _child_attr(entry, "link", "href") or _child_itertext(entry, "link") or source_url
+        summary = (
+            _child_itertext(entry, "summary")
+            or _child_itertext(entry, "content")
+            or ""
+        )
+        published = _parse_datetime(
+            _child_itertext(entry, "updated")
+            or _child_itertext(entry, "published")
+        )
+        cleaned = _clean_text(summary)
+        items.append(
+            {
+                "title": unescape(title.strip()),
+                "link": link.strip(),
+                "summary": _summarise(cleaned) if cleaned else "",
+                "source": source_name,
+                "published_at": published.isoformat().replace("+00:00", "Z") if published else None,
+            }
+        )
+    return items
+
+
+def _parse_rdf_feed(root: ElementTree.Element, source_url: str) -> Iterable[dict[str, Any]]:
+    source_name = _child_itertext(root, "title") or source_url
+    items: list[dict[str, Any]] = []
+    for item in root.findall(".//{*}item"):
+        title = _child_itertext(item, "title") or "(zonder titel)"
+        link = _child_itertext(item, "link") or source_url
+        summary = (
+            _child_itertext(item, "description")
+            or _child_itertext(item, "summary")
+            or ""
+        )
+        published = _parse_datetime(
+            _child_itertext(item, "date") or _child_itertext(item, "pubDate")
+        )
+        cleaned = _clean_text(summary)
+        items.append(
+            {
+                "title": unescape(title.strip()),
+                "link": link.strip(),
+                "summary": _summarise(cleaned) if cleaned else "",
+                "source": source_name,
+                "published_at": published.isoformat().replace("+00:00", "Z") if published else None,
+            }
+        )
+    return items
+
+
+def _parse_feed_document(payload: str, source_url: str) -> list[dict[str, Any]]:
+    try:
+        root = ElementTree.fromstring(payload)
+    except ElementTree.ParseError:
+        return []
+    tag = _strip_tag(root.tag).lower()
+    if tag == "rss":
+        return list(_parse_rss_feed(root, source_url))
+    if tag == "feed":
+        return list(_parse_atom_feed(root, source_url))
+    # some feeds use <rdf:RDF> for RSS 1.0
+    if tag in {"rdf", "rdf:rdf"}:
+        return list(_parse_rdf_feed(root, source_url))
+    return []
+
+
+def _fetch_feed_sync(url: str, timeout: int = 10) -> list[dict[str, Any]]:
+    request = URLRequest(url, headers={"User-Agent": "Photoframe/1.0"})
+    try:
+        with urlopen(request, timeout=timeout) as response:
+            data = response.read()
+            encoding = response.headers.get_content_charset("utf-8")
+    except (URLError, TimeoutError, ValueError):
+        return []
+    try:
+        text = data.decode(encoding or "utf-8", errors="replace")
+    except LookupError:
+        text = data.decode("utf-8", errors="replace")
+    return _parse_feed_document(text, url)
+
+
+async def _collect_news(urls: Iterable[str]) -> list[dict[str, Any]]:
+    loop = asyncio.get_running_loop()
+    tasks = [loop.run_in_executor(None, _fetch_feed_sync, url) for url in urls]
+    items: list[dict[str, Any]] = []
+    for result in await asyncio.gather(*tasks, return_exceptions=True):
+        if isinstance(result, Exception):
+            continue
+        items.extend(result)
+    return items
 
 
 @dataclass
@@ -173,6 +403,79 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
     @app.get("/index.html", include_in_schema=False)
     async def index_alias(request: Request, state: AppState = Depends(get_app_state)) -> HTMLResponse:
         return await index(request, state)
+
+    @app.get("/news", response_class=JSONResponse)
+    async def news_endpoint(
+        keywords: Optional[str] = None,
+        limit: int = 12,
+        hours: int = 72,
+        state: AppState = Depends(get_app_state),
+    ) -> JSONResponse:
+        feeds = DEFAULT_NEWS_FEEDS
+
+        async def _load() -> dict[str, Any]:
+            items = await _collect_news(feeds)
+            return {
+                "items": items,
+                "fetched_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            }
+
+        cached_bundle = await state.cache.get_or_load(
+            "news",
+            feeds,
+            _load,
+            ttl=300.0,
+            stale_ttl=900.0,
+        )
+
+        if isinstance(cached_bundle, dict):
+            raw_items_seq = cached_bundle.get("items") or []
+        else:  # pragma: no cover - defensive fallback
+            raw_items_seq = []
+        raw_items = list(raw_items_seq)
+
+        keyword_set = (
+            {token.strip().lower() for token in (keywords or "").split(",") if token.strip()}
+        )
+        now = datetime.now(timezone.utc)
+        fetched_at = (
+            _parse_datetime(cached_bundle.get("fetched_at"))
+            if isinstance(cached_bundle, dict)
+            else None
+        ) or now
+        cutoff = now - timedelta(hours=max(0, hours)) if hours > 0 else None
+
+        filtered: list[dict[str, Any]] = []
+        for item in raw_items:
+            published_iso = item.get("published_at")
+            published_dt = _parse_datetime(published_iso)
+            if cutoff and published_dt and published_dt < cutoff:
+                continue
+            if keyword_set:
+                haystack = " ".join(
+                    [item.get("title", ""), item.get("summary", ""), item.get("source", "")]
+                ).lower()
+                if not any(keyword in haystack for keyword in keyword_set):
+                    continue
+            filtered.append({**item, "published_at": published_iso})
+
+        fallback_time = datetime(1970, 1, 1, tzinfo=timezone.utc)
+        filtered.sort(
+            key=lambda entry: _parse_datetime(entry.get("published_at")) or fallback_time,
+            reverse=True,
+        )
+
+        limit = max(1, min(int(limit or 0) or 12, 50))
+        limited = filtered[:limit]
+
+        payload = {
+            "feeds": list(feeds),
+            "generated_at": fetched_at.isoformat().replace("+00:00", "Z"),
+            "keywords": sorted(keyword_set),
+            "item_count": len(limited),
+            "items": limited,
+        }
+        return JSONResponse(payload)
 
     from .api import config as config_routes
     from .api import logs, render, status, widgets

--- a/server/static/main.js
+++ b/server/static/main.js
@@ -62,6 +62,215 @@ async function refreshList() {
   }
 }
 
+class NewsBoard {
+  constructor(root) {
+    this.root = root;
+    this.statusEl = root.querySelector('.news-status');
+    this.listEl = root.querySelector('.news-list');
+    this.cacheKey = 'photoframe.news.cache.v1';
+    this.cacheDuration = 10 * 60 * 1000; // 10 minutes
+    this.refreshInterval = 5 * 60 * 1000; // refresh every 5 minutes
+    this.cached = this.loadCache();
+
+    if (this.cached && this.cached.items && this.cached.items.length) {
+      this.render(this.cached.items, { fromCache: true, stale: false });
+    }
+
+    this.refresh(true);
+    this.intervalId = window.setInterval(() => {
+      this.refresh(false);
+    }, this.refreshInterval);
+  }
+
+  loadCache() {
+    try {
+      const stored = window.localStorage.getItem(this.cacheKey);
+      if (!stored) return null;
+      const parsed = JSON.parse(stored);
+      if (!parsed || typeof parsed !== 'object') return null;
+      if (!Array.isArray(parsed.items)) return null;
+      if (typeof parsed.timestamp !== 'number') return null;
+      return parsed;
+    } catch (err) {
+      return null;
+    }
+  }
+
+  saveCache(data) {
+    try {
+      window.localStorage.setItem(this.cacheKey, JSON.stringify(data));
+    } catch (err) {
+      // ignore storage failures (private browsing, quota, ...)
+    }
+  }
+
+  setStatus(message) {
+    if (this.statusEl) {
+      this.statusEl.textContent = message;
+    }
+  }
+
+  formatRelative(date) {
+    if (!(date instanceof Date) || Number.isNaN(date.getTime())) {
+      return '';
+    }
+    const now = Date.now();
+    const diff = now - date.getTime();
+    const minute = 60 * 1000;
+    const hour = 60 * minute;
+    const day = 24 * hour;
+    if (diff < 0) {
+      return date.toLocaleString(undefined, {
+        day: '2-digit',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    }
+    if (diff < minute) return 'zojuist';
+    if (diff < hour) {
+      const minutes = Math.max(1, Math.round(diff / minute));
+      return `${minutes} min geleden`;
+    }
+    if (diff < day) {
+      const hours = Math.max(1, Math.round(diff / hour));
+      return `${hours} uur geleden`;
+    }
+    if (diff < 14 * day) {
+      const days = Math.max(1, Math.round(diff / day));
+      return `${days} dagen geleden`;
+    }
+    return date.toLocaleDateString(undefined, { day: '2-digit', month: 'short' });
+  }
+
+  formatUpdated(timestamp) {
+    if (!timestamp) return '';
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return '';
+    const diff = Date.now() - date.getTime();
+    if (diff < 60 * 1000) {
+      return 'zojuist bijgewerkt';
+    }
+    if (diff < 3600 * 1000) {
+      const minutes = Math.max(1, Math.round(diff / (60 * 1000)));
+      return `bijgewerkt ${minutes} min geleden`;
+    }
+    return `bijgewerkt ${date.toLocaleTimeString(undefined, {
+      hour: '2-digit',
+      minute: '2-digit',
+    })}`;
+  }
+
+  createArticle(item) {
+    const article = document.createElement('article');
+    article.className = 'news-item';
+
+    const heading = document.createElement('h3');
+    const link = document.createElement('a');
+    link.href = item.link || '#';
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = item.title || 'Onbekend bericht';
+    heading.appendChild(link);
+    article.appendChild(heading);
+
+    if (item.summary) {
+      const summary = document.createElement('p');
+      summary.className = 'news-summary';
+      summary.textContent = item.summary;
+      article.appendChild(summary);
+    }
+
+    const meta = document.createElement('p');
+    meta.className = 'news-meta';
+    const parts = [];
+    if (item.source) {
+      parts.push(item.source);
+    }
+    if (item.published_at) {
+      const date = new Date(item.published_at);
+      const relative = this.formatRelative(date);
+      if (relative) {
+        parts.push(relative);
+      }
+      meta.title = date.toLocaleString();
+    }
+    meta.textContent = parts.join(' • ');
+    article.appendChild(meta);
+
+    return article;
+  }
+
+  render(items, options = {}) {
+    const { fromCache = false, stale = false } = options;
+    if (!this.listEl) return;
+    this.listEl.innerHTML = '';
+
+    if (!items || !items.length) {
+      const empty = document.createElement('div');
+      empty.className = 'news-empty';
+      empty.textContent = 'Geen nieuwsartikelen gevonden.';
+      this.listEl.appendChild(empty);
+    } else {
+      const fragment = document.createDocumentFragment();
+      items.forEach((item) => {
+        fragment.appendChild(this.createArticle(item));
+      });
+      this.listEl.appendChild(fragment);
+    }
+
+    if (this.cached) {
+      const label = this.formatUpdated(this.cached.timestamp);
+      if (fromCache && stale) {
+        this.setStatus(label ? `offline • ${label}` : 'offline • nieuws uit cache');
+      } else if (fromCache) {
+        this.setStatus(label ? `cache • ${label}` : 'cache • nieuws opgeslagen');
+      } else {
+        this.setStatus(label || 'Nieuws bijgewerkt');
+      }
+    } else {
+      this.setStatus('Nieuws bijgewerkt');
+    }
+  }
+
+  async refresh(forceNetwork = false) {
+    const now = Date.now();
+    if (!forceNetwork && this.cached && now - this.cached.timestamp < this.cacheDuration) {
+      this.render(this.cached.items, { fromCache: true, stale: false });
+      return;
+    }
+
+    this.setStatus('Nieuws laden…');
+
+    try {
+      const response = await fetch('/news');
+      if (!response.ok) {
+        throw new Error(`Nieuwsrequest mislukt: ${response.status}`);
+      }
+      const payload = await response.json();
+      const normalized = {
+        timestamp: Date.now(),
+        items: Array.isArray(payload.items) ? payload.items.slice(0, 24) : [],
+        meta: {
+          feeds: payload.feeds || [],
+          generated_at: payload.generated_at || null,
+        },
+      };
+      this.cached = normalized;
+      this.saveCache(normalized);
+      this.render(normalized.items, { fromCache: false, stale: false });
+    } catch (err) {
+      if (this.cached && this.cached.items && this.cached.items.length) {
+        const stale = now - this.cached.timestamp > this.cacheDuration;
+        this.render(this.cached.items, { fromCache: true, stale });
+      } else {
+        this.render([], {});
+        this.setStatus('Kan nieuws niet laden.');
+      }
+    }
+  }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   const uploadForm = document.getElementById('uploadForm');
   uploadForm.addEventListener('submit', async (event) => {
@@ -98,4 +307,10 @@ document.addEventListener('DOMContentLoaded', () => {
   refreshStatus();
   refreshList();
   setInterval(refreshStatus, 5000);
+
+  const newsRoot = document.getElementById('newsBoard');
+  if (newsRoot) {
+    // eslint-disable-next-line no-new
+    new NewsBoard(newsRoot);
+  }
 });

--- a/server/static/style.css
+++ b/server/static/style.css
@@ -18,6 +18,87 @@ h1 {
   margin: 16px 0;
 }
 
+.section-news {
+  border-top: 2px solid #000;
+  padding-top: 16px;
+}
+
+.news-board {
+  border: 2px solid #111;
+  border-radius: 12px;
+  padding: 16px;
+  background: #fff;
+}
+
+.news-status {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+  color: #333;
+}
+
+.news-list {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.news-item {
+  border: 2px solid #000;
+  border-radius: 10px;
+  padding: 12px 14px;
+  background: #fefefe;
+  min-height: 150px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.news-item h3 {
+  margin: 0 0 8px 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.news-item h3 a {
+  color: #111;
+  text-decoration: none;
+  border-bottom: 1px solid transparent;
+}
+
+.news-item h3 a:hover,
+.news-item h3 a:focus {
+  border-color: #111;
+}
+
+.news-summary {
+  margin: 0 0 12px 0;
+  font-size: 0.95rem;
+  line-height: 1.4;
+  color: #1d1d1d;
+}
+
+.news-meta {
+  margin: 0;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #444;
+}
+
+.news-empty {
+  border: 2px dashed #777;
+  border-radius: 10px;
+  padding: 20px;
+  text-align: center;
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  color: #555;
+  text-transform: uppercase;
+}
+
 .row {
   display: flex;
   gap: 8px;
@@ -64,4 +145,14 @@ input[type="number"] {
 
 small {
   color: #666;
+}
+
+@media (max-width: 600px) {
+  .grid {
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  }
+
+  .news-list {
+    grid-template-columns: 1fr;
+  }
 }

--- a/server/templates/index.html
+++ b/server/templates/index.html
@@ -4,6 +4,14 @@
       <div id="status"><small>Loading status…</small></div>
     </div>
 
+    <div class="section section-news">
+      <h2>Nieuws</h2>
+      <div id="newsBoard" class="news-board">
+        <div class="news-status" role="status" aria-live="polite">Nieuws laden…</div>
+        <div class="news-list" role="list"></div>
+      </div>
+    </div>
+
     <div class="section">
       <h2>Upload</h2>
       <form id="uploadForm">


### PR DESCRIPTION
## Summary
- add `/news` FastAPI endpoint that aggregates, filters and caches RSS/Atom feeds
- extend the dashboard template, styles and JavaScript with a cached news board optimised for e-ink displays

## Testing
- pytest *(fails: missing fastapi / pillow dependencies in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d10d781afc832cb930898ec5a9e005