### PR TITLE
Add carousel-aware status endpoint

### DIFF
--- a/server/api/config.py
+++ b/server/api/config.py
@@ -39,6 +39,7 @@ async def update_config(
 
     rotation_changed = new_config.auto_rotate != current.auto_rotate
     state.set_runtime_config(new_config)
+    state.carousel.set_minutes(new_config.carousel_minutes)
 
     if rotation_changed:
         inky_display.set_rotation(new_config.auto_rotate)

--- a/server/api/status.py
+++ b/server/api/status.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+from dataclasses import asdict
 from typing import Optional, Tuple
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 
 from ..app import AppState, get_app_state
+from ..carousel import CarouselSnapshot
 from ..inky import display as inky_display
 from ..storage.files import describe_image, list_images_sorted
 
@@ -25,6 +27,21 @@ class PreviewResponse(BaseModel):
     url: Optional[str] = None
     size: Optional[int] = None
     created_at: Optional[str] = None
+
+
+class CarouselStatus(BaseModel):
+    running: bool
+    minutes: int
+    current_index: int
+    current_file: Optional[str]
+    next_switch_at: Optional[str]
+
+
+class StatusResponse(BaseModel):
+    ok: bool
+    display_ready: bool
+    target_size: Tuple[int, int]
+    carousel: CarouselStatus
 
 
 @router.get("/health", response_model=HealthResponse)
@@ -51,4 +68,30 @@ async def preview(state: AppState = Depends(get_app_state)) -> PreviewResponse:
         url=description["url"],
         size=description["size"],
         created_at=description["created_at"],
+    )
+
+
+@router.get("/status", response_model=StatusResponse)
+async def status_endpoint(state: AppState = Depends(get_app_state)) -> StatusResponse:
+    try:
+        display_ready = inky_display.is_ready()
+        target_size = inky_display.target_size()
+    except Exception as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Display status unavailable",
+        ) from exc
+
+    files = list(list_images_sorted(state.image_dir))
+    snapshot: CarouselSnapshot = state.carousel.snapshot(
+        files,
+        last_rendered=state.last_rendered,
+        default_minutes=state.runtime_config.carousel_minutes,
+    )
+
+    return StatusResponse(
+        ok=True,
+        display_ready=display_ready,
+        target_size=tuple(target_size),
+        carousel=CarouselStatus(**asdict(snapshot)),
     )

--- a/server/carousel.py
+++ b/server/carousel.py
@@ -1,0 +1,143 @@
+"""Utilities to track the carousel rendering state.
+
+This module mirrors the lightweight bookkeeping that existed in the
+legacy Flask implementation.  The FastAPI server keeps an instance of
+``CarouselState`` on the application state object so request handlers can
+inspect or update the most recent carousel activity without having to
+recreate the logic in multiple places.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional
+
+import threading
+
+
+@dataclass
+class CarouselSnapshot:
+    """Serialisable view of the carousel state."""
+
+    running: bool
+    minutes: int
+    current_index: int
+    current_file: Optional[str]
+    next_switch_at: Optional[str]
+
+
+class CarouselState:
+    """Thread-safe container for carousel metadata.
+
+    The class keeps track of whether the carousel is running, which file
+    is currently displayed and when the next automatic switch is
+    scheduled.  The numerical index is maintained primarily for
+    compatibility with the legacy dashboard which displayed the position
+    of the current image in the gallery.
+    """
+
+    def __init__(self, minutes: int = 5) -> None:
+        self._lock = threading.RLock()
+        self._running = False
+        self._minutes = max(1, int(minutes))
+        self._current_index = -1
+        self._current_file: Optional[str] = None
+        self._next_switch_at: Optional[datetime] = None
+
+    def set_minutes(self, minutes: int) -> None:
+        """Persist the configured carousel interval."""
+
+        with self._lock:
+            self._minutes = max(1, int(minutes))
+
+    def set_running(
+        self,
+        running: bool,
+        *,
+        minutes: Optional[int] = None,
+        next_switch_at: Optional[datetime] = None,
+    ) -> None:
+        """Update the running state and optional scheduling metadata."""
+
+        with self._lock:
+            self._running = running
+            if minutes is not None:
+                self._minutes = max(1, int(minutes))
+            self._next_switch_at = next_switch_at if running else None
+
+    def set_current(self, filename: Optional[str], index: int = -1) -> None:
+        """Record which file is currently displayed."""
+
+        with self._lock:
+            if filename is None:
+                self._current_file = None
+                self._current_index = -1
+            else:
+                self._current_file = filename
+                self._current_index = int(index)
+
+    def snapshot(
+        self,
+        files: Iterable[Path],
+        *,
+        last_rendered: Optional[str] = None,
+        default_minutes: Optional[int] = None,
+    ) -> CarouselSnapshot:
+        """Return a consistent snapshot of the carousel state.
+
+        The snapshot validates that the stored ``current_file`` still
+        exists in ``files`` and falls back to ``last_rendered`` when the
+        carousel has not yet been initialised for the FastAPI runtime.
+        """
+
+        file_list = list(files)
+        file_names = [path.name for path in file_list]
+
+        with self._lock:
+            minutes = self._minutes
+            running = self._running
+            current_index = self._current_index
+            current_file = self._current_file
+
+            # Synchronise the current index with the actual gallery
+            # contents.  When the state stems from a legacy render the
+            # ``last_rendered`` value helps to prime the state so the
+            # dashboard shows the correct image name straight away.
+            if current_file and current_file in file_names:
+                if not (0 <= current_index < len(file_names)) or file_names[current_index] != current_file:
+                    current_index = file_names.index(current_file)
+                    self._current_index = current_index
+            elif last_rendered and last_rendered in file_names:
+                current_file = last_rendered
+                current_index = file_names.index(last_rendered)
+                self._current_file = current_file
+                self._current_index = current_index
+            else:
+                current_file = None
+                current_index = -1
+                self._current_file = None
+                self._current_index = -1
+
+            if default_minutes is not None and not running:
+                minutes = max(1, int(default_minutes))
+                self._minutes = minutes
+
+            next_switch = (
+                self._next_switch_at.isoformat(timespec="seconds")
+                if self._next_switch_at
+                else None
+            )
+
+        return CarouselSnapshot(
+            running=running,
+            minutes=minutes,
+            current_index=current_index,
+            current_file=current_file,
+            next_switch_at=next_switch,
+        )
+
+
+__all__ = ["CarouselState", "CarouselSnapshot"]
+

--- a/tests/test_api_status.py
+++ b/tests/test_api_status.py
@@ -1,0 +1,75 @@
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "server" not in sys.modules:
+    server_module = types.ModuleType("server")
+    server_module.__path__ = [str(ROOT / "server")]
+    server_module.__spec__ = ModuleSpec("server", loader=None, is_package=True)
+    sys.modules["server"] = server_module
+
+if "server.inky" not in sys.modules:
+    inky_module = types.ModuleType("server.inky")
+    inky_module.__path__ = [str(ROOT / "server" / "inky")]
+    inky_module.__spec__ = ModuleSpec("server.inky", loader=None, is_package=True)
+    sys.modules["server.inky"] = inky_module
+
+if "server.inky.display" not in sys.modules:
+    display_stub = types.ModuleType("server.inky.display")
+    display_stub.set_rotation = lambda enabled: None  # type: ignore[arg-type]
+    display_stub.is_ready = lambda: True
+    display_stub.target_size = lambda: (600, 448)
+    display_stub.panel_size = lambda: (600, 448)
+    display_stub.display_image = lambda img: None
+    sys.modules["server.inky.display"] = display_stub
+
+from server.app import ServerConfig, create_app
+
+
+def _create_client(tmp_path: Path) -> TestClient:
+    config = ServerConfig(image_dir=tmp_path)
+    app = create_app(config)
+    return TestClient(app)
+
+
+def test_status_endpoint_returns_latest_state(tmp_path: Path) -> None:
+    client = _create_client(tmp_path)
+    app = client.app
+    state = app.state.photoframe
+
+    image = tmp_path / "sample.jpg"
+    image.write_bytes(b"data")
+    state.last_rendered = image.name
+
+    response = client.get("/status")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["ok"] is True
+    assert payload["display_ready"] is True
+    assert payload["target_size"] == [600, 448]
+    assert payload["carousel"]["minutes"] == state.runtime_config.carousel_minutes
+    assert payload["carousel"]["current_file"] == image.name
+    assert payload["carousel"]["current_index"] == 0
+
+
+def test_status_endpoint_handles_display_errors(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = _create_client(tmp_path)
+
+    def _raise() -> bool:
+        raise RuntimeError("boom")
+
+    display_module = sys.modules["server.inky.display"]
+    monkeypatch.setattr(display_module, "is_ready", _raise)
+
+    response = client.get("/status")
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Display status unavailable"}


### PR DESCRIPTION
## Summary
- add a dedicated `CarouselState` helper to keep track of carousel metadata for the FastAPI app
- expose a `/status` endpoint that reports display readiness together with the latest carousel snapshot
- keep the carousel interval in sync with runtime config updates and cover the new handler with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d124ed8e68832ca549c13a9006a313