### PR TITLE
Add FastAPI upload endpoint and tests

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,5 +1,13 @@
 """API routers for the photoframe FastAPI application."""
 
-from . import config, logs, render, status, weather, widgets
+from . import config, logs, render, status, uploads, weather, widgets
 
-__all__ = ["config", "logs", "render", "status", "weather", "widgets"]
+__all__ = [
+    "config",
+    "logs",
+    "render",
+    "status",
+    "uploads",
+    "weather",
+    "widgets",
+]

--- a/server/api/uploads.py
+++ b/server/api/uploads.py
@@ -1,0 +1,124 @@
+"""Upload endpoint for processing images via FastAPI."""
+
+from __future__ import annotations
+
+import io
+import os
+from typing import Any
+from urllib.parse import quote
+
+from fastapi import APIRouter, Depends, Request, status
+from fastapi.responses import JSONResponse
+from starlette.datastructures import UploadFile
+
+from ..app import AppState, get_app_state
+from ..storage.files import ALLOWED_EXT, save_image
+from ..image_processing import open_image_first_frame, resize_fill_inky
+
+router = APIRouter(tags=["uploads"])
+
+_MAX_TOTAL_BYTES = 200 * 1024 * 1024
+
+
+def _json_response(
+    *,
+    ok: bool,
+    saved: list[dict[str, Any]],
+    errors: list[dict[str, str]],
+    status_code: int,
+    message: str | None = None,
+) -> JSONResponse:
+    payload: dict[str, Any] = {"ok": ok, "saved": saved, "errors": errors}
+    if message:
+        payload["error"] = message
+    return JSONResponse(payload, status_code=status_code)
+
+
+def _collect_uploads(form_data: Any) -> list[UploadFile]:
+    if hasattr(form_data, "getlist"):
+        candidates = form_data.getlist("file")
+    else:  # pragma: no cover - defensive
+        candidates = []
+    return [item for item in candidates if isinstance(item, UploadFile)]
+
+
+@router.post("/upload", response_class=JSONResponse)
+async def upload_images(
+    request: Request,
+    state: AppState = Depends(get_app_state),
+) -> JSONResponse:
+    content_type = request.headers.get("content-type", "")
+    if "multipart/form-data" not in content_type.lower():
+        message = "Content-Type must be multipart/form-data"
+        return _json_response(
+            ok=False,
+            saved=[],
+            errors=[{"file": "", "error": message}],
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message=message,
+        )
+
+    try:
+        form_data = await request.form()
+    except Exception:
+        message = "Invalid multipart payload"
+        return _json_response(
+            ok=False,
+            saved=[],
+            errors=[{"file": "", "error": message}],
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message=message,
+        )
+
+    uploads = _collect_uploads(form_data)
+    if not uploads:
+        message = "No files were provided"
+        return _json_response(
+            ok=False,
+            saved=[],
+            errors=[{"file": "", "error": message}],
+            status_code=status.HTTP_400_BAD_REQUEST,
+            message=message,
+        )
+
+    saved: list[dict[str, str]] = []
+    errors: list[dict[str, str]] = []
+    total_bytes = 0
+
+    for upload in uploads:
+        filename = upload.filename or "upload"
+        try:
+            ext = os.path.splitext(filename)[1].lower()
+            if ext not in ALLOWED_EXT:
+                raise ValueError(f"Unsupported file type: {ext}")
+
+            data = await upload.read()
+            total_bytes += len(data)
+            if total_bytes > _MAX_TOTAL_BYTES:
+                raise ValueError("Files too large in total")
+
+            buffer = io.BytesIO(data)
+            image = open_image_first_frame(buffer)
+            processed = resize_fill_inky(image)
+            out_path = save_image(processed, filename, state.image_dir)
+            saved.append({"file": out_path.name, "url": f"/image/{quote(out_path.name)}"})
+        except Exception as exc:  # pragma: no cover - error path tested separately
+            errors.append({"file": filename, "error": str(exc)})
+        finally:
+            await upload.close()
+
+    ok = bool(saved) and not errors
+    status_code = status.HTTP_200_OK if ok else (
+        status.HTTP_207_MULTI_STATUS if saved else status.HTTP_400_BAD_REQUEST
+    )
+    message = None if ok else (errors[0]["error"] if errors else "Upload error")
+    return _json_response(
+        ok=ok,
+        saved=saved,
+        errors=errors,
+        status_code=status_code,
+        message=message,
+    )
+
+
+__all__ = ["router", "upload_images"]

--- a/server/app.py
+++ b/server/app.py
@@ -482,12 +482,13 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         return JSONResponse(payload)
 
     from .api import config as config_routes
-    from .api import logs, render, status, weather, widgets
+    from .api import logs, render, status, uploads, weather, widgets
 
     app.include_router(status.router)
     app.include_router(render.router)
     app.include_router(config_routes.router)
     app.include_router(weather.router)
+    app.include_router(uploads.router)
     app.include_router(widgets.router)
     app.include_router(logs.router)
 

--- a/server/image_processing.py
+++ b/server/image_processing.py
@@ -1,0 +1,48 @@
+"""Shared image helpers for upload processing."""
+
+from __future__ import annotations
+
+import io
+
+from PIL import Image, ImageOps
+
+from .inky import display as inky_display
+
+
+def open_image_first_frame(buf: io.BytesIO) -> Image.Image:
+    buf.seek(0)
+    img = Image.open(buf)
+    try:
+        img = ImageOps.exif_transpose(img)
+    except Exception:  # pragma: no cover - defensive
+        pass
+    if getattr(img, "is_animated", False):
+        try:
+            img.seek(0)
+        except Exception:  # pragma: no cover - defensive
+            pass
+    return img
+
+
+def resize_fill_inky(img: Image.Image) -> Image.Image:
+    target_width, target_height = inky_display.target_size()
+    if img.width < img.height:
+        img = img.transpose(Image.Transpose.ROTATE_90)
+
+    target_ratio = target_width / target_height
+    source_width, source_height = img.width, img.height
+    source_ratio = source_width / source_height
+
+    if source_ratio > target_ratio:
+        new_width = int(source_height * target_ratio)
+        left = (source_width - new_width) // 2
+        img = img.crop((left, 0, left + new_width, source_height))
+    else:
+        new_height = int(source_width / target_ratio)
+        top = (source_height - new_height) // 2
+        img = img.crop((0, top, source_width, top + new_height))
+
+    return img.convert("RGB").resize((target_width, target_height), Image.Resampling.LANCZOS)
+
+
+__all__ = ["open_image_first_frame", "resize_fill_inky"]

--- a/tests/test_uploads.py
+++ b/tests/test_uploads.py
@@ -1,0 +1,106 @@
+import io
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "server" not in sys.modules:
+    server_module = types.ModuleType("server")
+    server_module.__path__ = [str(ROOT / "server")]
+    server_module.__spec__ = ModuleSpec("server", loader=None, is_package=True)
+    sys.modules["server"] = server_module
+
+if "server.inky" not in sys.modules:
+    inky_module = types.ModuleType("server.inky")
+    inky_module.__path__ = [str(ROOT / "server" / "inky")]
+    inky_module.__spec__ = ModuleSpec("server.inky", loader=None, is_package=True)
+    sys.modules["server.inky"] = inky_module
+
+if "server.inky.display" not in sys.modules:
+    display_stub = types.ModuleType("server.inky.display")
+    display_stub.set_rotation = lambda enabled: None  # type: ignore[arg-type]
+    display_stub.is_ready = lambda: True
+    display_stub.target_size = lambda: (600, 448)
+    display_stub.panel_size = lambda: (600, 448)
+    display_stub.display_image = lambda img: None
+    sys.modules["server.inky.display"] = display_stub
+
+from server.app import ServerConfig, create_app
+
+
+def _create_client(tmp_path: Path) -> TestClient:
+    config = ServerConfig(image_dir=tmp_path)
+    app = create_app(config)
+    return TestClient(app)
+
+
+def _make_image_bytes(color: str) -> bytes:
+    image = Image.new("RGB", (800, 600), color=color)
+    buffer = io.BytesIO()
+    image.save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def test_upload_multiple_images_success(tmp_path: Path) -> None:
+    client = _create_client(tmp_path)
+
+    files = [
+        ("file", ("one.png", _make_image_bytes("red"), "image/png")),
+        ("file", ("two.jpeg", _make_image_bytes("blue"), "image/jpeg")),
+    ]
+
+    response = client.post("/upload", files=files)
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["errors"] == []
+    assert len(payload["saved"]) == 2
+
+    saved_files = {entry["file"] for entry in payload["saved"]}
+    on_disk = {path.name for path in tmp_path.iterdir()}
+    assert saved_files <= on_disk
+
+
+def test_upload_partial_success(tmp_path: Path) -> None:
+    client = _create_client(tmp_path)
+
+    files = [
+        ("file", ("valid.png", _make_image_bytes("green"), "image/png")),
+        ("file", ("invalid.txt", b"not-an-image", "text/plain")),
+    ]
+
+    response = client.post("/upload", files=files)
+    assert response.status_code == 207
+
+    payload = response.json()
+    assert payload["ok"] is False
+    assert len(payload["saved"]) == 1
+    assert len(payload["errors"]) == 1
+    assert payload["errors"][0]["file"] == "invalid.txt"
+    assert "Unsupported file type" in payload["errors"][0]["error"]
+
+    saved_files = [entry["file"] for entry in payload["saved"]]
+    for name in saved_files:
+        assert (tmp_path / name).exists()
+
+
+def test_upload_invalid_payload(tmp_path: Path) -> None:
+    client = _create_client(tmp_path)
+
+    response = client.post("/upload", data={"foo": "bar"})
+    assert response.status_code == 400
+
+    payload = response.json()
+    assert payload["ok"] is False
+    assert payload["saved"] == []
+    assert len(payload["errors"]) == 1
+    assert payload["errors"][0]["error"] == "Content-Type must be multipart/form-data"
+    assert payload["error"] == "Content-Type must be multipart/form-data"


### PR DESCRIPTION
## Summary
- add a FastAPI `/upload` endpoint that reuses the legacy image helpers and returns the UI-friendly payload
- extract shared image processing helpers and wire the uploads router into the main application
- cover full success, partial success, and invalid payload scenarios with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d12dd93848832c898a9682c4cb007f