### PR TITLE
Add FastAPI image management endpoints

### DIFF
--- a/server/api/__init__.py
+++ b/server/api/__init__.py
@@ -1,9 +1,10 @@
 """API routers for the photoframe FastAPI application."""
 
-from . import config, logs, render, status, uploads, weather, widgets
+from . import config, images, logs, render, status, uploads, weather, widgets
 
 __all__ = [
     "config",
+    "images",
     "logs",
     "render",
     "status",

--- a/server/api/images.py
+++ b/server/api/images.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Optional
+from urllib.parse import unquote
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi.responses import JSONResponse, Response
+from PIL import Image, ImageOps
+
+from ..app import AppState, get_app_state
+from ..inky import display as inky_display
+from ..storage.files import describe_image, list_images_sorted
+
+router = APIRouter(tags=["images"])
+
+
+def _detail_text(exc: HTTPException) -> str:
+    detail = exc.detail
+    if isinstance(detail, str):
+        return detail
+    return str(detail)
+
+
+def _image_path(name: str, state: AppState) -> Path:
+    safe_name = os.path.basename(unquote(name))
+    path = state.image_dir / safe_name
+    if not path.exists() or not path.is_file():
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Image not found")
+    return path
+
+
+@router.get("/list")
+async def list_images(state: AppState = Depends(get_app_state)) -> dict:
+    items = []
+    for path in list_images_sorted(state.image_dir):
+        try:
+            items.append(describe_image(path))
+        except Exception:
+            continue
+    return {"ok": True, "items": items}
+
+
+@router.get("/image/{name:path}")
+async def image_endpoint(name: str, state: AppState = Depends(get_app_state)) -> Response:
+    path = _image_path(name, state)
+    data = path.read_bytes()
+    suffix = path.suffix.lower()
+    if suffix in {".jpg", ".jpeg"}:
+        media_type = "image/jpeg"
+    elif suffix == ".png":
+        media_type = "image/png"
+    else:
+        media_type = "application/octet-stream"
+    return Response(content=data, media_type=media_type)
+
+
+@router.post("/display", response_class=JSONResponse)
+async def display_image(
+    file: Optional[str] = Query(None, alias="file"),
+    state: AppState = Depends(get_app_state),
+) -> JSONResponse:
+    if not file:
+        return JSONResponse({"ok": False, "error": "Missing ?file="}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    if not inky_display.is_ready():
+        return JSONResponse(
+            {"ok": False, "error": "Inky display not available"},
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    try:
+        path = _image_path(file, state)
+    except HTTPException as exc:
+        return JSONResponse({"ok": False, "error": _detail_text(exc)}, status_code=exc.status_code)
+
+    try:
+        with path.open("rb") as handle:
+            image = Image.open(handle)
+            processed = ImageOps.exif_transpose(image).convert("RGB")
+        inky_display.display_image(processed)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    files = list(list_images_sorted(state.image_dir))
+    index = next((i for i, candidate in enumerate(files) if candidate.name == path.name), -1)
+    state.carousel.set_current(path.name if index >= 0 else None, index=index)
+    state.last_rendered = path.name
+    return JSONResponse({"ok": True})
+
+
+@router.post("/delete", response_class=JSONResponse)
+async def delete_image(
+    file: Optional[str] = Query(None, alias="file"),
+    state: AppState = Depends(get_app_state),
+) -> JSONResponse:
+    if not file:
+        return JSONResponse({"ok": False, "error": "Missing ?file="}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    try:
+        path = _image_path(file, state)
+    except HTTPException as exc:
+        return JSONResponse({"ok": False, "error": _detail_text(exc)}, status_code=exc.status_code)
+
+    files_before = list(list_images_sorted(state.image_dir))
+    snapshot = state.carousel.snapshot(
+        files_before,
+        last_rendered=state.last_rendered,
+        default_minutes=state.runtime_config.carousel_minutes,
+    )
+
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        return JSONResponse({"ok": False, "error": "Image not found"}, status_code=status.HTTP_404_NOT_FOUND)
+    except Exception as exc:
+        return JSONResponse({"ok": False, "error": str(exc)}, status_code=status.HTTP_400_BAD_REQUEST)
+
+    if state.last_rendered == path.name:
+        state.last_rendered = None
+
+    remaining = [candidate for candidate in files_before if candidate.name != path.name]
+    remaining_names = [candidate.name for candidate in remaining]
+
+    if not remaining_names:
+        state.carousel.set_current(None)
+    else:
+        current_index = snapshot.current_index
+        current_file = snapshot.current_file
+        if current_index < 0:
+            state.carousel.set_current(None)
+        else:
+            if current_file not in remaining_names:
+                new_index = min(max(current_index, 0), len(remaining_names) - 1)
+                new_file = remaining_names[new_index]
+            else:
+                new_index = remaining_names.index(current_file)
+                new_file = current_file
+            state.carousel.set_current(new_file, index=new_index)
+
+    return JSONResponse({"ok": True})
+
+
+__all__ = ["router", "list_images", "image_endpoint", "display_image", "delete_image"]

--- a/server/app.py
+++ b/server/app.py
@@ -482,8 +482,9 @@ def create_app(config: Optional[ServerConfig] = None) -> FastAPI:
         return JSONResponse(payload)
 
     from .api import config as config_routes
-    from .api import logs, render, status, uploads, weather, widgets
+    from .api import images, logs, render, status, uploads, weather, widgets
 
+    app.include_router(images.router)
     app.include_router(status.router)
     app.include_router(render.router)
     app.include_router(config_routes.router)

--- a/tests/test_images_api.py
+++ b/tests/test_images_api.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import sys
+import types
+from importlib.machinery import ModuleSpec
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+if "server" not in sys.modules:
+    server_module = types.ModuleType("server")
+    server_module.__path__ = [str(ROOT / "server")]
+    server_module.__spec__ = ModuleSpec("server", loader=None, is_package=True)
+    sys.modules["server"] = server_module
+
+if "server.inky" not in sys.modules:
+    inky_module = types.ModuleType("server.inky")
+    inky_module.__path__ = [str(ROOT / "server" / "inky")]
+    inky_module.__spec__ = ModuleSpec("server.inky", loader=None, is_package=True)
+    sys.modules["server.inky"] = inky_module
+
+if "server.inky.display" not in sys.modules:
+    display_stub = types.ModuleType("server.inky.display")
+    display_stub.set_rotation = lambda enabled: None  # type: ignore[arg-type]
+    display_stub.is_ready = lambda: True
+    display_stub.target_size = lambda: (600, 448)
+    display_stub.panel_size = lambda: (600, 448)
+    display_stub.display_image = lambda img: None
+    sys.modules["server.inky.display"] = display_stub
+
+from server.app import ServerConfig, create_app
+from server.storage.files import list_images_sorted
+
+
+def _create_client(tmp_path: Path) -> TestClient:
+    config = ServerConfig(image_dir=tmp_path)
+    app = create_app(config)
+    return TestClient(app)
+
+
+def _create_image(path: Path, color: str = "red") -> None:
+    image = Image.new("RGB", (32, 32), color=color)
+    image.save(path, format="JPEG")
+
+
+def test_list_images_returns_metadata(tmp_path: Path) -> None:
+    first = tmp_path / "alpha.jpg"
+    second = tmp_path / "bravo.png"
+    first.write_bytes(b"data")
+    second.write_bytes(b"other")
+
+    client = _create_client(tmp_path)
+
+    response = client.get("/list")
+    assert response.status_code == 200
+    payload = response.json()
+
+    assert payload["ok"] is True
+    names = [item["name"] for item in payload["items"]]
+    assert names == sorted(names)
+    urls = {item["url"] for item in payload["items"]}
+    assert f"/image/{first.name}" in urls
+    assert f"/image/{second.name}" in urls
+
+
+def test_display_missing_file_returns_404(tmp_path: Path) -> None:
+    client = _create_client(tmp_path)
+
+    response = client.post("/display", params={"file": "missing.jpg"})
+    assert response.status_code == 404
+    assert response.json() == {"ok": False, "error": "Image not found"}
+
+
+def test_display_handles_offline_display(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    image_path = tmp_path / "sample.jpg"
+    _create_image(image_path)
+
+    client = _create_client(tmp_path)
+
+    display_module = sys.modules["server.inky.display"]
+    monkeypatch.setattr(display_module, "is_ready", lambda: False)
+
+    response = client.post("/display", params={"file": image_path.name})
+    assert response.status_code == 503
+    assert response.json() == {"ok": False, "error": "Inky display not available"}
+
+
+def test_delete_removes_file_and_updates_state(tmp_path: Path) -> None:
+    first = tmp_path / "alpha.jpg"
+    second = tmp_path / "bravo.jpg"
+    _create_image(first, color="blue")
+    _create_image(second, color="green")
+
+    client = _create_client(tmp_path)
+    state = client.app.state.photoframe
+
+    # display the first image to seed the carousel state
+    response = client.post("/display", params={"file": first.name})
+    assert response.status_code == 200
+
+    response = client.post("/delete", params={"file": first.name})
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+
+    assert not first.exists()
+    remaining = list(list_images_sorted(state.image_dir))
+    assert remaining and remaining[0].name == second.name
+
+    snapshot = state.carousel.snapshot(
+        remaining,
+        last_rendered=state.last_rendered,
+        default_minutes=state.runtime_config.carousel_minutes,
+    )
+    assert snapshot.current_file == second.name
+    assert snapshot.current_index == 0


### PR DESCRIPTION
## Summary
- add a FastAPI router that serves gallery listings, image files, display and delete actions while updating shared carousel state
- wire the new router into the application factory so the endpoints are exposed alongside the existing status routes
- cover the new behaviour with tests for listing, display error handling and delete flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d138139328832c9ce131ead144c0ff