### PR TITLE
Revamp display layout and widget styling

### DIFF
--- a/src/smart_display/widgets/agenda.py
+++ b/src/smart_display/widgets/agenda.py
@@ -24,57 +24,93 @@ class AgendaWidget(Widget[List[AgendaEvent]]):
 
     def draw(self, image: Image.Image, draw: ImageDraw.ImageDraw, context: WidgetContext, data: List[AgendaEvent]) -> None:
         palette = context.palette
-        area = context.area.inset(24, 24)
-        draw.rectangle([area.left, area.top, area.right, area.bottom], fill=(255, 255, 255), outline=palette.muted, width=3)
+        card_area = context.area.inset(12, 12)
+        draw.rounded_rectangle(
+            [card_area.left, card_area.top, card_area.right, card_area.bottom],
+            radius=28,
+            fill=(255, 255, 255),
+            outline=tuple(min(255, c + 20) for c in palette.muted),
+            width=2,
+        )
 
-        header_font = load_font(36, bold=True)
-        sub_font = load_font(20)
-        body_font = load_font(24)
+        area = card_area.inset(32, 32)
+        header_font = load_font(40, bold=True)
+        sub_font = load_font(22, bold=True)
+        body_font = load_font(26)
+        detail_font = load_font(21)
 
-        draw.text((area.left + 12, area.top + 8), "Agenda", fill=palette.primary, font=header_font)
-        y = area.top + 8 + _text_height(header_font)
+        header_y = area.top
+        draw.text((area.left, header_y), "Today's Agenda", fill=palette.primary, font=header_font)
+        y = header_y + _text_height(header_font) + 16
+        draw.line([(area.left, y), (area.right, y)], fill=tuple(min(255, c + 40) for c in palette.muted), width=2)
+        y += 20
 
         if not data:
             draw.text(
-                (area.left + 12, y + 16),
+                (area.left, y),
                 "No upcoming events",
                 fill=palette.muted,
                 font=body_font,
             )
             return
 
-        day = None
+        current_day = None
         for event in data:
             event_day = event.start.date()
-            if day != event_day:
-                day = event_day
-                day_label = event.start.strftime("%A %d %b")
-                draw.text((area.left + 12, y + 20), day_label, fill=palette.secondary, font=sub_font)
-                y += 20 + _text_height(sub_font)
+            if current_day != event_day:
+                current_day = event_day
+                day_label = event.start.strftime("%A, %d %B")
+                draw.text((area.left, y), day_label, fill=palette.secondary, font=sub_font)
+                y += _text_height(sub_font) + 12
 
             time_range = _format_time_range(event, context.now)
-            draw.text((area.left + 12, y + 12), time_range, fill=palette.accent, font=body_font)
+            badge_height = _text_height(body_font) + 18
+            badge_width = _text_width(body_font, time_range) + 32
+            badge_bottom = y + badge_height
+
+            draw.rounded_rectangle(
+                [area.left, y, area.left + badge_width, badge_bottom],
+                radius=badge_height // 2,
+                fill=palette.accent,
+            )
             draw.text(
-                (area.left + 160, y + 12),
+                (area.left + 16, y + (badge_height - _text_height(body_font)) // 2),
+                time_range,
+                fill=(255, 255, 255),
+                font=body_font,
+            )
+
+            text_x = area.left + badge_width + 24
+            draw.text(
+                (text_x, y + 4),
                 event.title,
                 fill=palette.primary,
                 font=body_font,
             )
-            y += 12 + _text_height(body_font)
+            text_bottom = y + 4 + _text_height(body_font)
             if event.location:
+                location_y = text_bottom + 6
                 draw.text(
-                    (area.left + 160, y + 4),
+                    (text_x, location_y),
                     event.location,
                     fill=palette.secondary,
-                    font=sub_font,
+                    font=detail_font,
                 )
-                y += 4 + _text_height(sub_font)
-            y += 8
+                text_bottom = location_y + _text_height(detail_font)
+
+            y = max(badge_bottom, text_bottom) + 20
+            if y > area.bottom - _text_height(body_font):
+                break
 
 
 def _text_height(font) -> int:
     bbox = font.getbbox("Hg")
     return bbox[3] - bbox[1]
+
+
+def _text_width(font, text: str) -> int:
+    bbox = font.getbbox(text)
+    return bbox[2] - bbox[0]
 
 
 def _format_time_range(event: AgendaEvent, now: datetime) -> str:

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -10,10 +10,15 @@ def test_layout_areas_cover_display():
     news = layout.area("news")
     market = layout.area("market")
 
-    assert agenda.left == 0 and agenda.top == 0
-    assert agenda.right == settings.width
-    assert agenda.bottom == news.top
-    assert news.bottom == settings.height
-    assert market.bottom == settings.height
-    assert market.right == settings.width
-    assert news.right == market.left
+    margin = agenda.left
+
+    assert margin == agenda.top
+    assert settings.width - agenda.right == margin
+    assert settings.height - news.bottom == margin
+
+    gutter = news.top - agenda.bottom
+    assert gutter == market.top - agenda.bottom
+    assert gutter == market.left - news.right
+
+    assert news.bottom == market.bottom
+    assert agenda.right == market.right


### PR DESCRIPTION
## Summary
- add generous margins and a subtle gradient background to the layout canvas to anchor widgets cleanly
- restyle agenda, news, and market widgets with rounded cards, refreshed typography, and richer visual accents
- enhance the market sparkline with a framed chart area and update layout tests for the new spacing model

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d42efb4654832ca181b96ac7c2c67e