### PR TITLE
Refine display styling with Terminal-inspired aesthetic

### DIFF
--- a/src/smart_display/display/style.py
+++ b/src/smart_display/display/style.py
@@ -20,14 +20,28 @@ class Palette:
 
 
 DEFAULT_PALETTE = Palette(
-    background=(240, 240, 236),  # warm white
-    primary=(38, 38, 38),  # deep charcoal
-    secondary=(88, 88, 88),
-    accent=(220, 76, 70),  # inky red
-    positive=(32, 142, 72),  # deep green
-    muted=(120, 120, 120),
-    warning=(255, 185, 0),  # amber highlight
+    background=(12, 17, 26),  # deep navy
+    primary=(231, 238, 247),  # soft white
+    secondary=(148, 163, 184),  # slate
+    accent=(94, 234, 212),  # aqua accent
+    positive=(129, 230, 217),
+    muted=(71, 85, 105),
+    warning=(250, 204, 21),
 )
+
+
+def lighten(color: Tuple[int, int, int], amount: float) -> Tuple[int, int, int]:
+    """Return a colour blended towards white by ``amount``."""
+
+    amount = max(0.0, min(1.0, amount))
+    return tuple(int(channel + (255 - channel) * amount) for channel in color)
+
+
+def darken(color: Tuple[int, int, int], amount: float) -> Tuple[int, int, int]:
+    """Return a colour blended towards black by ``amount``."""
+
+    amount = max(0.0, min(1.0, amount))
+    return tuple(int(channel * (1 - amount)) for channel in color)
 
 
 def _font_candidates(bold: bool) -> Tuple[str, ...]:
@@ -54,4 +68,4 @@ def load_font(size: int, *, bold: bool = False) -> ImageFont.FreeTypeFont:
     return ImageFont.load_default()
 
 
-__all__ = ["DEFAULT_PALETTE", "load_font", "Palette"]
+__all__ = ["DEFAULT_PALETTE", "load_font", "Palette", "lighten", "darken"]

--- a/src/smart_display/widgets/agenda.py
+++ b/src/smart_display/widgets/agenda.py
@@ -8,7 +8,7 @@ from PIL import Image, ImageDraw
 
 from ..config import AgendaSettings
 from ..data.agenda import AgendaDataProvider, AgendaEvent
-from ..display.style import load_font
+from ..display.style import lighten, load_font
 from .base import Widget, WidgetContext
 
 
@@ -24,34 +24,47 @@ class AgendaWidget(Widget[List[AgendaEvent]]):
 
     def draw(self, image: Image.Image, draw: ImageDraw.ImageDraw, context: WidgetContext, data: List[AgendaEvent]) -> None:
         palette = context.palette
-        card_area = context.area.inset(12, 12)
+        card_area = context.area.inset(10, 10)
+        card_fill = lighten(palette.background, 0.14)
+        border_colour = lighten(palette.muted, 0.25)
         draw.rounded_rectangle(
             [card_area.left, card_area.top, card_area.right, card_area.bottom],
-            radius=28,
-            fill=(255, 255, 255),
-            outline=tuple(min(255, c + 20) for c in palette.muted),
+            radius=30,
+            fill=card_fill,
+            outline=border_colour,
             width=2,
         )
 
-        area = card_area.inset(32, 32)
-        header_font = load_font(40, bold=True)
-        sub_font = load_font(22, bold=True)
-        body_font = load_font(26)
-        detail_font = load_font(21)
+        accent_bar_height = 10
+        draw.rounded_rectangle(
+            [card_area.left, card_area.top, card_area.right, card_area.top + accent_bar_height],
+            radius=5,
+            fill=lighten(palette.accent, 0.2),
+        )
+
+        area = card_area.inset(30, 32)
+        header_font = load_font(36, bold=True)
+        sub_font = load_font(20, bold=True)
+        body_font = load_font(24)
+        detail_font = load_font(20)
 
         header_y = area.top
-        draw.text((area.left, header_y), "Today's Agenda", fill=palette.primary, font=header_font)
-        y = header_y + _text_height(header_font) + 16
-        draw.line([(area.left, y), (area.right, y)], fill=tuple(min(255, c + 40) for c in palette.muted), width=2)
-        y += 20
+        draw.text(
+            (area.left, header_y),
+            "TODAY'S AGENDA",
+            fill=palette.primary,
+            font=header_font,
+        )
+        y = header_y + _text_height(header_font) + 12
+        draw.line(
+            [(area.left, y), (area.right, y)],
+            fill=lighten(palette.muted, 0.1),
+            width=2,
+        )
+        y += 18
 
         if not data:
-            draw.text(
-                (area.left, y),
-                "No upcoming events",
-                fill=palette.muted,
-                font=body_font,
-            )
+            draw.text((area.left, y), "NO UPCOMING EVENTS", fill=palette.secondary, font=sub_font)
             return
 
         current_day = None
@@ -60,18 +73,19 @@ class AgendaWidget(Widget[List[AgendaEvent]]):
             if current_day != event_day:
                 current_day = event_day
                 day_label = event.start.strftime("%A, %d %B")
-                draw.text((area.left, y), day_label, fill=palette.secondary, font=sub_font)
-                y += _text_height(sub_font) + 12
+                draw.text((area.left, y), day_label.upper(), fill=palette.secondary, font=sub_font)
+                y += _text_height(sub_font) + 10
 
             time_range = _format_time_range(event, context.now)
             badge_height = _text_height(body_font) + 18
             badge_width = _text_width(body_font, time_range) + 32
             badge_bottom = y + badge_height
 
+            badge_fill = lighten(palette.accent, 0.15)
             draw.rounded_rectangle(
                 [area.left, y, area.left + badge_width, badge_bottom],
                 radius=badge_height // 2,
-                fill=palette.accent,
+                fill=badge_fill,
             )
             draw.text(
                 (area.left + 16, y + (badge_height - _text_height(body_font)) // 2),
@@ -93,7 +107,7 @@ class AgendaWidget(Widget[List[AgendaEvent]]):
                 draw.text(
                     (text_x, location_y),
                     event.location,
-                    fill=palette.secondary,
+                    fill=lighten(palette.secondary, 0.12),
                     font=detail_font,
                 )
                 text_bottom = location_y + _text_height(detail_font)


### PR DESCRIPTION
## Summary
- adopt a darker, Terminal-inspired colour palette and utilities for shading
- refresh the base canvas with gradient lighting to better showcase content
- restyle the agenda, news, and market widgets with cohesive cards, typography, and accents

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4386fdd30832cbfdb9f82c92c57aa