### PR TITLE
Defer smart_display imports to eliminate runpy warning

### DIFF
--- a/src/smart_display/__init__.py
+++ b/src/smart_display/__init__.py
@@ -1,5 +1,22 @@
 """Smart Display package."""
 
-from .app import SmartDisplayApp
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import only for type checking
+    from .app import SmartDisplayApp as _SmartDisplayApp
 
 __all__ = ["SmartDisplayApp"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - thin re-export shim
+    if name == "SmartDisplayApp":
+        from .app import SmartDisplayApp
+
+        return SmartDisplayApp
+    raise AttributeError(name)
+
+
+def __dir__() -> list[str]:  # pragma: no cover - thin re-export shim
+    return sorted(__all__)

--- a/src/smart_display/web/__init__.py
+++ b/src/smart_display/web/__init__.py
@@ -1,5 +1,31 @@
 """Web configuration server package."""
 
-from .server import create_app, launch_config_server
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:  # pragma: no cover - imported only for typing
+    from ..config import ConfigManager, WebSettings
 
 __all__ = ["create_app", "launch_config_server"]
+
+
+def create_app(
+    config_manager: "ConfigManager",
+    refresh_callback: Optional[Callable[[], None]] = None,
+):
+    from .server import create_app as _create_app
+
+    return _create_app(config_manager, refresh_callback=refresh_callback)
+
+
+def launch_config_server(
+    settings: "WebSettings",
+    config_manager: "ConfigManager",
+    refresh_callback: Optional[Callable[[], None]] = None,
+):
+    from .server import launch_config_server as _launch_config_server
+
+    return _launch_config_server(
+        settings, config_manager, refresh_callback=refresh_callback
+    )


### PR DESCRIPTION
## Summary
- defer importing the application and web server modules until they are accessed so that `python -m smart_display.web.server` no longer emits a RuntimeWarning

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4428c6bb8832cbb2e7e203119ce62